### PR TITLE
Better hint for release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@
 # Usage:
 #   on:
 #     release:
+#       types: [published]
 
 name: Release
 


### PR DESCRIPTION
Without specifying the release type, release CI gets invoked three times.