### PR TITLE
Only run CodeQL on pushes, not pulls

### DIFF
--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -183,5 +183,6 @@ jobs:
 
   codeql:
     needs: commit-updated-env
+    if: github.event_name == 'push'  # This task is pretty time-consuming, so only do it on pushes
     uses: pyiron/actions/.github/workflows/codeql.yml@main
     secrets: inherit


### PR DESCRIPTION
I find that this is often the slowest test in my CI chain and I'm tired of waiting for it to pass before merging. I'd like to delay it until further downstream so it doesn't slow down the merging of PRs -- especially a sequence of multiple small, manageable PRs, which is exactly the good behaviour we don't want to penalize. I'm not sure I've ever seen this test fail, so I'd like to run it later and less often.

On the other hand, this is a security issue. We run CodeQL as a cron job weekly anyhow, and IMO a brief window of vulnerability between the push going through and rolling back any PR that winds up failing this test is probably not an existential threat given the nature of our codebase.

I've been super cavalier pushing to this repo, but this is something I'd appreciate a quick but sober second opinion on.