### PR TITLE
Run CodeQL on label rather than push/pull

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,12 @@
 # This runs GitHub's codeql security analysis
-# Usage:
+# Recommended usage:
 #   on:
 #     schedule:
 #       - cron: '0 23 * * 2'  # Weekly on Tuesdays at 23:00 UTC, for example
 # And/or:
-#   on:
-#     push:
-#       branches: [ main ]
-#     pull_request:
-#       branches: [ main ]
+# on:
+#   pull_request:
+#     types: [labeled]
 
 name: Code scanning
 

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -53,3 +53,9 @@ jobs:
         env-label: linux-64-py-3-10
         env-files: ${{ inputs.tests-env-files }}
         test-dir: tests/integration
+
+  code-ql:
+    if: contains(github.event.pull_request.labels.*.name, 'CodeQL')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: pyiron/actions/.github/workflows/codeql.yml@main

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -181,8 +181,3 @@ jobs:
         with:
           options: "--check --diff"
           src: ./${{ github.event.repository.name }}
-
-  codeql:
-    needs: commit-updated-env
-    uses: pyiron/actions/.github/workflows/codeql.yml@main
-    secrets: inherit


### PR DESCRIPTION
Instead of running CodeQL so frequently (every pull), and to avoid having it give a red X on the main branch (every push) just run when labeled. (Also still usable as a scheduled cron job, which is also recommended in case old code _becomes_ unsafe). 

[Since August](https://github.blog/changelog/2022-08-22-github-actions-improvements-to-reusable-workflows-2/) you can nest reusable workflows like this.