### PR TITLE
Rearrange tests

### DIFF
--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -52,7 +52,7 @@ jobs:
         env-prefix: /usr/share/miniconda3/envs/my-env
         env-label: linux-64-py-3-10
         env-files: ${{ inputs.tests-env-files }}
-        test-dir: tests/integration
+        test-dir: tests
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'CodeQL')

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -56,6 +56,8 @@ jobs:
     - name: Coverage
       continue-on-error: True
       shell: bash -l {0}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         coverage combine
         coveralls --service=github

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -41,8 +41,8 @@ jobs:
           github_token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
           branch: ${{ github.event.pull_request.head.ref }}
 
-  integration-tests:
-    if: contains(github.event.pull_request.labels.*.name, 'integration')
+  tests-and-coverage:
+    if: contains(github.event.pull_request.labels.*.name, 'tests')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -54,7 +54,6 @@ jobs:
         env-files: ${{ inputs.tests-env-files }}
         test-dir: tests
     - name: Coverage
-      continue-on-error: True
       shell: bash -l {0}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +62,6 @@ jobs:
         coveralls --service=github
         coverage xml
     - name: Codacy
-      continue-on-error: True
       shell: bash -l {0}
       run: |
         python-codacy-coverage -r coverage.xml

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -53,6 +53,18 @@ jobs:
         env-label: linux-64-py-3-10
         env-files: ${{ inputs.tests-env-files }}
         test-dir: tests
+    - name: Coverage
+      continue-on-error: True
+      shell: bash -l {0}
+      run: |
+        coverage combine
+        coveralls --service=github
+        coverage xml
+    - name: Codacy
+      continue-on-error: True
+      shell: bash -l {0}
+      run: |
+        python-codacy-coverage -r coverage.xml
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'CodeQL')

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -132,20 +132,6 @@ jobs:
         env-label: ${{ matrix.label }}
         env-files: ${{ inputs.tests-env-files }}
         test-dir: tests/unit
-    - name: Coverage
-      if: matrix.label == 'linux-64-py-3-10'
-      continue-on-error: True
-      shell: bash -l {0}
-      run: |
-        coverage combine
-        coveralls --service=github
-        coverage xml
-    - name: Codacy
-      if: matrix.label == 'linux-64-py-3-10' && github.event_name != 'push'
-      continue-on-error: True
-      shell: bash -l {0}
-      run: |
-        python-codacy-coverage -r coverage.xml
 
   benchmark-tests:
     needs: commit-updated-env


### PR DESCRIPTION
Changes the "integration" label to "tests", and uses it to run integration, benchmark, and unit tests, and then runs coverage and codacy on the result. Coverage and codacy are meanwhile completely removed from the on-push-pull workflows.

This way coverage and codacy will see *all* the tests, and main won't get a red X if coverage drops (since we won't run on push).

Pending the merge of #15 (which this branched off of) and any revelations in #16.