### PR TITLE
Explicitly add the token to the env

### DIFF
--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -136,6 +136,8 @@ jobs:
       if: matrix.label == 'linux-64-py-3-10'
       continue-on-error: True
       shell: bash -l {0}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         coverage combine
         coveralls --service=github


### PR DESCRIPTION
I ran into trouble over on ironflow at this step `Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.`, and sure enough [their docs explicitly pass the token to the env](https://github.com/TheKevJames/coveralls-python/blob/master/docs/usage/configuration.rst#github-actions-support)