### PR TITLE
Add token value to env

### DIFF
--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -41,5 +41,7 @@ jobs:
           coverage xml
       - name: Codacy
         shell: bash -l {0}
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: |
           python-codacy-coverage -r coverage.xml


### PR DESCRIPTION
Over in ironflow I get the following error, maybe because there is now two layers of workflows? `ERROR - environment variable CODACY_PROJECT_TOKEN is not defined.`