### PR TITLE
Be more explicit about the service name

### DIFF
--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Coverage
         shell: bash -l {0}
         env:
+          COVERALLS_SERVICE_NAME: 'github'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           coverage combine


### PR DESCRIPTION
[per the docs](https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support) the service name can be "picky". Since the `github-actions` service explicitly requires the `COVERALLS_REPO_TOKEN ` token, and my daily workflow error messages contain `set the COVERALLS_REPO_TOKEN env var.`, I think that's a good hint that the service is not being parsed correctly.

At worst, this is just redundant and we can roll it back.