### PR TITLE
Remove kernel specification

### DIFF
--- a/.support/build_notebooks.sh
+++ b/.support/build_notebooks.sh
@@ -13,7 +13,7 @@ fi
 # execute notebooks
 i=0;
 for notebook in $(ls ${NOTEBOOKS_DIR}/*.ipynb); do
-    papermill ${notebook} ${notebook%.*}-out.${notebook##*.} -k $kernel || i=$((i+1));
+    papermill ${notebook} ${notebook%.*}-out.${notebook##*.} || i=$((i+1));
 done;
 
 # push error to next level


### PR DESCRIPTION
In the `build_notebooks.sh` invocation of papermill. This is a holdover from when we supported python 2.7. The variable isn't even set in the script any more.