### PR TITLE
Use the same setup as base and atomistics for coveralls

### DIFF
--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -19,6 +19,9 @@ on:
         default: .ci_support/environment.yml
         required: false
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   Tests-and-Coverage:
     runs-on: ubuntu-latest
@@ -33,12 +36,9 @@ jobs:
           test-dir: tests
       - name: Coverage
         shell: bash -l {0}
-        env:
-          COVERALLS_SERVICE_NAME: 'github'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           coverage combine
-          coveralls --service=github
+          coveralls
           coverage xml
       - name: Codacy
         shell: bash -l {0}


### PR DESCRIPTION
I continue to get token validation issues with the daily workflow, despite following the docs (which have a disclaimer that things might not work perfectly for me), so let's just do it the way base and atomistics do it because things are working fine there.