### PR TITLE
Fail as intended for to short lists

### DIFF
--- a/.support/update_environment.py
+++ b/.support/update_environment.py
@@ -72,9 +72,10 @@ def ends_in_yml(s):
 
 
 def pattern_is_bump_from_to(list_):
+    if len(list_) != 9: 
+        return False
     return all(
         [
-            len(list_) == 9,
             list_[1] == 'Bump',
             list_[3] == 'from',
             list_[5] == 'to',
@@ -84,9 +85,10 @@ def pattern_is_bump_from_to(list_):
 
 
 def pattern_is_update_requirement_from_to(list_):
+    if len(list_) != 10:
+        return False
     return all(
         [
-            len(list_) == 10,
             list_[1] == 'Update',
             list_[3] == 'requirement',
             list_[4] == 'from',


### PR DESCRIPTION
In recent pyiron_contrib dependabot PRs (e.g. https://github.com/pyiron/pyiron_contrib/pull/696), the number of arguments was wrong (different issue) and the action failed (as intended). However, not with the nice massage we intended (see below). This hopefully fixes this.

```
Run pyiron/actions/update-env-files@main
  with:
    conda-yml: .ci_support/environment.yml
Run pip install pyyaml
  pip install pyyaml
  shell: /usr/bin/bash -l {0}
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: pyyaml in /usr/lib/python[3](https://github.com/pyiron/pyiron_contrib/actions/runs/5111616226/jobs/9188774199#step:3:3)/dist-packages (5.[4](https://github.com/pyiron/pyiron_contrib/actions/runs/5111616226/jobs/9188774199#step:3:5).1)
Run python $GITHUB_ACTION_PATH/../.support/update_environment.py Bump pyiron-base from 0.[5](https://github.com/pyiron/pyiron_contrib/actions/runs/5111616226/jobs/9188774199#step:3:6).3[8](https://github.com/pyiron/pyiron_contrib/actions/runs/5111616226/jobs/9188774199#step:3:10) to 0.5.3[9](https://github.com/pyiron/pyiron_contrib/actions/runs/5111616226/jobs/9188774199#step:3:11)  $GITHUB_ACTION_PATH/../.support/pypi_vs_conda_names.json
  python $GITHUB_ACTION_PATH/../.support/update_environment.py Bump pyiron-base from 0.5.38 to 0.5.39  $GITHUB_ACTION_PATH/../.support/pypi_vs_conda_names.json
  shell: /usr/bin/bash -l {0}
Traceback (most recent call last):
  File "/home/runner/work/_actions/pyiron/actions/main/update-env-files/../.support/update_environment.py", line [10](https://github.com/pyiron/pyiron_contrib/actions/runs/5111616226/jobs/9188774199#step:3:12)3, in <module>
    if not matches_dependabot_pattern_for_yaml_update(sys.argv):
  File "/home/runner/work/_actions/pyiron/actions/main/update-env-files/../.support/update_environment.py", line 100, in matches_dependabot_pattern_for_yaml_update
    return pattern_is_bump_from_to(list_) or pattern_is_update_requirement_from_to(list_)
  File "/home/runner/work/_actions/pyiron/actions/main/update-env-files/../.support/update_environment.py", line 94, in pattern_is_update_requirement_from_to
    ends_in_yml(list_[8])
IndexError: list index out of range
Error: Process completed with exit code 1.
```