### PR TITLE
Sync input variable used with input variable declared

### DIFF
--- a/update-env-files/action.yml
+++ b/update-env-files/action.yml
@@ -16,4 +16,4 @@ runs:
     run: pip install pyyaml
   - name: Update environment files
     shell: bash -l {0}
-    run: python $GITHUB_ACTION_PATH/../.support/update_environment.py ${{ github.event.pull_request.title }} ${{ inputs.conda-env }} $GITHUB_ACTION_PATH/../.support/pypi_vs_conda_names.json
+    run: python $GITHUB_ACTION_PATH/../.support/update_environment.py ${{ github.event.pull_request.title }} ${{ inputs.conda-yml }} $GITHUB_ACTION_PATH/../.support/pypi_vs_conda_names.json


### PR DESCRIPTION
We declare `conda-yml` but try to use `conda-env`. This is what was giving the length errors that led to the cleanup in #42. This should now fix the underlying issue so we don't see that cleaner error 😉 