### PR TITLE
Replace python 3.8 in unit tests matrix with python 3.11

### DIFF
--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -109,6 +109,11 @@ jobs:
             prefix: C:\Miniconda3\envs\my-env
 
           - operating-system: ubuntu-latest
+            python-version: '3.11'
+            label: linux-64-py-3-11
+            prefix: /usr/share/miniconda3/envs/my-env
+
+          - operating-system: ubuntu-latest
             python-version: '3.10'
             label: linux-64-py-3-10
             prefix: /usr/share/miniconda3/envs/my-env
@@ -116,11 +121,6 @@ jobs:
           - operating-system: ubuntu-latest
             python-version: 3.9
             label: linux-64-py-3-9
-            prefix: /usr/share/miniconda3/envs/my-env
-
-          - operating-system: ubuntu-latest
-            python-version: 3.8
-            label: linux-64-py-3-8
             prefix: /usr/share/miniconda3/envs/my-env
 
     steps:


### PR DESCRIPTION
The latest version of numpy (1.25) dropped 3.8 support. Let's also ditch it and add 3.11 to the tests.