### PR TITLE
Use globstar to run notebooks in subdirs

### DIFF
--- a/.support/build_notebooks.sh
+++ b/.support/build_notebooks.sh
@@ -11,12 +11,10 @@ if [ ${EXCLUSION_FILE} != "" ]; then
 fi
 
 # execute notebooks
-shopt -s globstar
 i=0;
-for notebook in ${NOTEBOOKS_DIR}/**/*.ipynb; do
+for notebook in $(find ${NOTEBOOKS_DIR} -type f -name '*.ipynb'); do
     papermill ${notebook} ${notebook%.*}-out.${notebook##*.} || i=$((i+1));
 done;
-shopt -u globstar
 
 # push error to next level
 if [ $i -gt 0 ]; then

--- a/.support/build_notebooks.sh
+++ b/.support/build_notebooks.sh
@@ -11,10 +11,12 @@ if [ ${EXCLUSION_FILE} != "" ]; then
 fi
 
 # execute notebooks
+shopt -s globstar
 i=0;
-for notebook in $(ls ${NOTEBOOKS_DIR}/*.ipynb); do
+for notebook in ${NOTEBOOKS_DIR}/**/*.ipynb; do
     papermill ${notebook} ${notebook%.*}-out.${notebook##*.} || i=$((i+1));
 done;
+shopt -u globstar
 
 # push error to next level
 if [ $i -gt 0 ]; then

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ These docs wind up getting discarded when the virtual machine (VM) for your job 
 ### `build-notebooks`
 
 Uses [papermill](https://papermill.readthedocs.io) to make sure that selected notebooks in your repository build and execute OK.
-You can exclude a notebook from this check by naming it in an exclusion file (this is empty by default, but for repos inside the pyiron organization using the workflow here that calls this action, the default location is `.ci_support/exclude`)
+You can exclude a notebook from this check by naming it in an exclusion file (this is empty by default, but for repos inside the pyiron organization using the workflow here that calls this action, the default location is `.ci_support/exclude`).
+Notebooks are found in all sub directories of `/notebooks`.  The files listed in the exclusion file must be given as relative paths to that folder.
 
 ### `cached-mamba`
 


### PR DESCRIPTION
Previously workflow doesn't run notebooks in sub directories, like

root/notebooks/foo/bar.ipynb

Using the `**` notation fixes this.  `EXCLUSION_FILE` should still work, but I haven't checked.