### PR TITLE
Refactor env declaration for caching mamba

### DIFF
--- a/cached-mamba/action.yml
+++ b/cached-mamba/action.yml
@@ -31,15 +31,13 @@ runs:
       channel-priority: strict
       activate-environment: my-env
       use-mamba: true
-  - name: Set cache date and number
-    shell: bash -l {0}
-    run: |
-      echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
   - uses: actions/cache@v2
     with:
       path: ${{ inputs.env-prefix }}
       key: ${{ inputs.env-label }}-conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}
     id: cache
+    env:
+      DATE: $(date +'%Y%m%d')
   - name: Update environment
     shell: bash -l {0}
     run: mamba env update -n my-env -f environment.yml


### PR DESCRIPTION
According to my (limited) experience in pyiron/docker-stack it should be possible to add the date to the `env` of the respective step itself. 