### PR TITLE
Expanding the python path

### DIFF
--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -36,6 +36,11 @@ on:
         description: 'How many minutes to allow tests in units/benchmark to run for'
         default: 30
         required: false
+      tests-in-python-path:
+        type: boolean
+        description: 'Whether to add the canonical test dirs (tests/( ,benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239).'
+        default: false
+        required: false
 
 jobs:
   commit-updated-env:  # Keep envs read by external sources (binder and readthedocs) up-to-date
@@ -125,6 +130,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: pyiron/actions/add-to-python-path@tests_in_python_path
+      if: ${{ inputs.tests-in-python-path }}
+      with:
+        path-dirs: tests tests/benchmark tests/integration tests/unit
     - uses: pyiron/actions/unit-tests@main
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -130,7 +130,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: pyiron/actions/add-to-python-path@tests_in_pythonpath
+    - uses: pyiron/actions/add-to-python-path@main
       if: ${{ inputs.tests-in-python-path }}
       with:
         path-dirs: tests tests/benchmark tests/integration tests/unit
@@ -144,7 +144,7 @@ jobs:
 
   coveralls-and-codacy:
     needs: commit-updated-env
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@tests_in_pythonpath
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@main
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -130,7 +130,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: pyiron/actions/add-to-python-path@tests_in_python_path
+    - uses: pyiron/actions/add-to-python-path@tests_in_pythonpath
       if: ${{ inputs.tests-in-python-path }}
       with:
         path-dirs: tests tests/benchmark tests/integration tests/unit

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -144,10 +144,11 @@ jobs:
 
   coveralls-and-codacy:
     needs: commit-updated-env
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@main
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@tests_in_pythonpath
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
+      tests-in-python-path: ${{ inputs.tests-in-python-path }}
 
   benchmark-tests:
     needs: commit-updated-env

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pyiron/actions/add-to-python-path@tests_in_pythonpath
+      - uses: pyiron/actions/add-to-python-path@main
         if: ${{ inputs.tests-in-python-path }}
         with:
           path-dirs: tests tests/benchmark tests/integration tests/unit

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -18,12 +18,21 @@ on:
         description: 'Paths to an arbitrary number of (space-separated) conda environment yaml files'
         default: .ci_support/environment.yml
         required: false
+      tests-in-python-path:
+        type: boolean
+        description: 'Whether to add the canonical test dirs (tests/( ,benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239).'
+        default: false
+        required: false
 
 jobs:
   Tests-and-Coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: pyiron/actions/add-to-python-path@tests_in_pythonpath
+        if: ${{ inputs.tests-in-python-path }}
+        with:
+          path-dirs: tests tests/benchmark tests/integration tests/unit
       - uses: pyiron/actions/unit-tests@main
         with:
           python-version: '3.11'

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ You will need to do this yourself in the calling workflow in order for these act
 
 ## The Actions
 
+### `add-to-python-path`
+
+Adds an arbitrary number of local repo directories to the python path, pre-pending the path to that directory as it is found on the local runner.
+This is sent to the `$GITHUB_ENV` so the expanded path is available in all further steps of the same job.
+
+In a pyiron context, this is important for repos that use `pympipool` in order to be able to use patterns like `python -m unittest discover tests` instead of `cd tests; python -m unittest discover .` by making sure `tests` (and/or sub-directories) are available in the python path.
+
 ### `build-docs`
 
 Combines your code's environment file with a separate environment file for building documentation (`.support/environment-docs.yml` from this repo by default) and uses [sphinx](https://www.sphinx-doc.org) to build a set of HTML documentation.

--- a/add-to-python-path/action.yml
+++ b/add-to-python-path/action.yml
@@ -1,5 +1,5 @@
 name: 'Add to python path'
-description: 'Add local directories to the PYTHONPATH github environment'
+description: 'Add local repo directories to the PYTHONPATH github environment'
 
 inputs:
   path-dirs:

--- a/add-to-python-path/action.yml
+++ b/add-to-python-path/action.yml
@@ -1,0 +1,22 @@
+name: 'Add to python path'
+description: 'Add local directories to the PYTHONPATH github environment'
+
+inputs:
+  path-dirs:
+    description: 'Paths to an arbitrary number of (space-separated) directories in the repo'
+    type: string
+    default:
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Add to python path
+      if: ${{ inputs.path-dirs != '' }}
+      shell: bash -l {0}
+      run: |
+        PWD=$(pwd)
+        for dir in ${{ inputs.path-dirs }}; do
+          PYTHONPATH=${PWD}/${dir}:${PYTHONPATH}
+        done
+        echo "PYTHONPATH=${PYTHONPATH}" >> $GITHUB_ENV


### PR DESCRIPTION
To use `pympipool` in other repos [e.g. `pyiron_workflow](https://github.com/pyiron/pyiron_workflow/pull/77), we either need to invoke unit tests from the directory the test files live in, or expand the python path to include those files (cf. [this issue](https://github.com/pyiron/pympipool/issues/239) and [this PR with examples](https://github.com/pyiron/pympipool/pull/238)). Unfortunately, github [does not make it easy to pass env variables to reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations). So, instead, here I'm introducing a new action for easily adding local directories (i.e. prepending the full runner path to the local repo paths provided) to the python path. It needs to be invoked _every job_ since the env is not shared between jobs, so I've started doing that in the reusable workflows based on a boolean flag input.

I still haven't found a great way to test and debug these workflows, so for the moment the reusable workflow actually has an explicit reference to this branch's tag.