### PR TITLE
Expose OS and py versions as input on reusable workflows

### DIFF
--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -177,7 +177,7 @@ jobs:
 
   coveralls-and-codacy:
     needs: commit-updated-env
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@main
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@flexible_matrix
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -134,21 +134,22 @@ jobs:
     # All three runners for the highest python version
     # Only the main for up to two more versions of python
     strategy:
-      operating-system: [${{ inputs.runner }}, ${{ inputs.runner-alt1 }}, ${{ inputs.runner-alt2 }}]
-      python-version: [${{ inputs.python-version }}, ${{ inputs.python-version-alt1 }}, ${{ inputs.python-version-alt2 }}]
-      exclude:
-        # Get rid of all combinations of alternative runners and alternative python versions
-        - operating-system: ${{ inputs.runner-alt1 }}
-          python-version: ${{ inputs.python-version-alt1 }}
-        - operating-system: ${{ inputs.runner-alt1 }}
-          python-version: ${{ inputs.python-version-alt2 }}
-        - operating-system: ${{ inputs.runner-alt2 }}
-          python-version: ${{ inputs.python-version-alt1 }}
-        - operating-system: ${{ inputs.runner-alt2 }}
-          python-version: ${{ inputs.python-version-alt2 }}
-        # Don't run anything tagged with "exclude"
-        - operating-system: 'exclude'
-        - python-version: 'exclude'
+      matrix:
+        operating-system: [${{ inputs.runner }}, ${{ inputs.runner-alt1 }}, ${{ inputs.runner-alt2 }}]
+        python-version: [${{ inputs.python-version }}, ${{ inputs.python-version-alt1 }}, ${{ inputs.python-version-alt2 }}]
+        exclude:
+          # Get rid of all combinations of alternative runners and alternative python versions
+          - operating-system: ${{ inputs.runner-alt1 }}
+            python-version: ${{ inputs.python-version-alt1 }}
+          - operating-system: ${{ inputs.runner-alt1 }}
+            python-version: ${{ inputs.python-version-alt2 }}
+          - operating-system: ${{ inputs.runner-alt2 }}
+            python-version: ${{ inputs.python-version-alt1 }}
+          - operating-system: ${{ inputs.runner-alt2 }}
+            python-version: ${{ inputs.python-version-alt2 }}
+          # Don't run anything tagged with "exclude"
+          - operating-system: 'exclude'
+          - python-version: 'exclude'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -160,7 +160,7 @@ jobs:
     - name: replace-dot
       run: |
         pyversion_string=${{ matrix.python-version }}
-        echo "pyversion_string=${pyversion_string/\./-}" >> $GITHUB_OUTPUTS
+        echo "pyversion_string=${pyversion_string/\./-}" >> $GITHUB_OUTPUT
     - uses: pyiron/actions/unit-tests@main
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -56,17 +56,17 @@ on:
         description: 'The runner version for Ubuntu: ubuntu-*'
         default: 'latest'
         required: false
-      tests-python-main:
+      python-version:
         type: string
         description: 'The main version of python to test on, used across all three OS for tests and in other steps'
         default: '3.11'
         required: false
-      tests-python-alt1:
+      python-version-alt1:
         type: string
         description: 'An alternate  version of python to test on, used only on linux'
         default: '3.10'
         required: false
-      tests-python-alt2:
+      python-version-alt2:
         type: string
         description: 'An alternate  version of python to test on, used only on linux'
         default: '3.9'
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pyiron/actions/build-docs@main
         with:
-          python-version: ${{ inputs.tests-python-main }}
+          python-version: ${{ inputs.python-version }}
           env-prefix: /usr/share/miniconda3/envs/my-env
           env-label: linux-64-py-main
           env-files: ${{ inputs.docs-env-files }}
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pyiron/actions/build-notebooks@main
         with:
-          python-version: ${{ inputs.tests-python-main }}
+          python-version: ${{ inputs.python-version }}
           env-prefix: /usr/share/miniconda3/envs/my-env
           env-label: linux-64-py-main
           env-files: ${{ inputs.notebooks-env-files }}
@@ -137,27 +137,27 @@ jobs:
       matrix:
         include:
           - operating-system: macos-latest
-            python-version: ${{ inputs.tests-python-main }}
+            python-version: ${{ inputs.python-version }}
             label: osx-64-py-main
             prefix: /Users/runner/miniconda3/envs/my-env
 
           - operating-system: windows-latest
-            python-version: ${{ inputs.tests-python-main }}
+            python-version: ${{ inputs.python-version }}
             label: win-64-py-main
             prefix: C:\Miniconda3\envs\my-env
 
           - operating-system: ubuntu-latest
-            python-version: ${{ inputs.tests-python-main }}
+            python-version: ${{ inputs.python-version }}
             label: linux-64-py-main
             prefix: /usr/share/miniconda3/envs/my-env
 
           - operating-system: ubuntu-latest
-            python-version: ${{ inputs.tests-python-alt1 }}
+            python-version: ${{ inputs.python-version-alt1 }}
             label: linux-64-py-alt1
             prefix: /usr/share/miniconda3/envs/my-env
 
           - operating-system: ubuntu-latest
-            python-version: ${{ inputs.tests-python-alt2 }}
+            python-version: ${{ inputs.python-version-alt2 }}
             label: linux-64-py-alt2
             prefix: /usr/share/miniconda3/envs/my-env
 
@@ -182,7 +182,7 @@ jobs:
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
       tests-in-python-path: ${{ inputs.tests-in-python-path }}
-      python-version: ${{ inputs.tests-python-main }}
+      python-version: ${{ inputs.python-version }}
 
   benchmark-tests:
     needs: commit-updated-env
@@ -191,7 +191,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: pyiron/actions/unit-tests@main
       with:
-        python-version: ${{ inputs.tests-python-main }}
+        python-version: ${{ inputs.python-version }}
         env-prefix: /usr/share/miniconda3/envs/my-env
         env-label: linux-64-py-main
         env-files: ${{ inputs.tests-env-files }}
@@ -205,7 +205,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pyiron/actions/pip-check@main
         with:
-          python-version: ${{ inputs.tests-python-main }}
+          python-version: ${{ inputs.python-version }}
           env-prefix: /usr/share/miniconda3/envs/my-env
           env-label: linux-64-py-main
 

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -134,37 +134,21 @@ jobs:
     # All three runners for the highest python version
     # Only the main for up to two more versions of python
     strategy:
-      matrix:
-        include:
-          - operating-system: ${{ inputs.runner-alt2 }}
-            python-version: ${{ inputs.python-version }}
-            label: ${{ inputs.runner-alt2 }}-py-main
-            prefix: /Users/runner/miniconda3/envs/my-env
-            do_run: ${{ inputs.runner-alt2 != 'exclude' }}
-
-          - operating-system: ${{ inputs.runner-alt1 }}
-            python-version: ${{ inputs.python-version }}
-            label: ${{ inputs.runner-alt1 }}-py-main
-            prefix: C:\Miniconda3\envs\my-env
-            do_run: ${{ inputs.runner-alt1 != 'exclude' }}
-
-          - operating-system: ${{ inputs.runner }}
-            python-version: ${{ inputs.python-version }}
-            label: ${{ inputs.runner }}-py-main
-            prefix: /usr/share/miniconda3/envs/my-env
-            do_run: true  # Always run the main runner with the main python version
-
-          - operating-system: ${{ inputs.runner }}
-            python-version: ${{ inputs.python-version-alt1 }}
-            label: ${{ inputs.runner }}-py-alt1
-            prefix: /usr/share/miniconda3/envs/my-env
-            do_run: ${{ inputs.python-version-alt1 != 'exclude' }}
-
-          - operating-system: ${{ inputs.runner }}
-            python-version: ${{ inputs.python-version-alt2 }}
-            label: ${{ inputs.runner }}-py-alt2
-            prefix: /usr/share/miniconda3/envs/my-env
-            do_run: ${{ inputs.python-version-alt2 != 'exclude' }}
+      operating-system: [${{ inputs.runner }}, ${{ inputs.runner-alt1 }}, ${{ inputs.runner-alt2 }}]
+      python-version: [${{ inputs.python-version }}, ${{ inputs.python-version-alt1 }}, ${{ inputs.python-version-alt2 }}]
+      exclude:
+        # Get rid of all combinations of alternative runners and alternative python versions
+        - operating-system: ${{ inputs.runner-alt1 }}
+          python-version: ${{ inputs.python-version-alt1 }}
+        - operating-system: ${{ inputs.runner-alt1 }}
+          python-version: ${{ inputs.python-version-alt2 }}
+        - operating-system: ${{ inputs.runner-alt2 }}
+          python-version: ${{ inputs.python-version-alt1 }}
+        - operating-system: ${{ inputs.runner-alt2 }}
+          python-version: ${{ inputs.python-version-alt2 }}
+        # Don't run anything tagged with "exclude"
+        - operating-system: 'exclude'
+        - python-version: 'exclude'
 
     steps:
     - uses: actions/checkout@v3
@@ -172,13 +156,15 @@ jobs:
       if: ${{ inputs.tests-in-python-path }}
       with:
         path-dirs: tests tests/benchmark tests/integration tests/unit
+    - name: replace-dot
+      run: |
+        PYVERSION=${{ matrix.python-version }}
+        echo "PYVERSION=${PYVERSION/\./-}" >> $GITHUB_ENV
     - uses: pyiron/actions/unit-tests@main
-      if: ${{ matrix.do_run }}
-      # It would be more elegant to skip earlier, but I'm not sure how to accomplish that
       with:
         python-version: ${{ matrix.python-version }}
-        env-prefix: ${{ matrix.prefix }}
-        env-label: ${{ matrix.label }}
+        env-prefix: ${{ contains('macos', matrix.operating-system) && '/Users/runner/miniconda3/envs/my-env' || contains('windows', matrix.operating-system) && 'C:\Miniconda3\envs\my-env' || contains('ubuntu', matrix.operating-system) && '/usr/share/miniconda3/envs/my-env }}
+        env-label: ${{ matrix.operating-system }}-py-${{ PYVERSION }}
         env-files: ${{ inputs.tests-env-files }}
         test-dir: tests/unit
 

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -159,13 +159,13 @@ jobs:
         path-dirs: tests tests/benchmark tests/integration tests/unit
     - name: replace-dot
       run: |
-        PYVERSION=${{ matrix.python-version }}
-        echo "PYVERSION=${PYVERSION/\./-}" >> $GITHUB_ENV
+        pyversion_string=${{ matrix.python-version }}
+        echo "pyversion_string=${pyversion_string/\./-}" >> $GITHUB_OUTPUTS
     - uses: pyiron/actions/unit-tests@main
       with:
         python-version: ${{ matrix.python-version }}
         env-prefix: ${{ contains('macos', matrix.operating-system) && '/Users/runner/miniconda3/envs/my-env' || contains('windows', matrix.operating-system) && 'C:\Miniconda3\envs\my-env' || contains('ubuntu', matrix.operating-system) && '/usr/share/miniconda3/envs/my-env }}
-        env-label: ${{ matrix.operating-system }}-py-${{ PYVERSION }}
+        env-label: ${{ matrix.operating-system }}-py-${{ steps.vars.outputs.pyversion_string }}
         env-files: ${{ inputs.tests-env-files }}
         test-dir: tests/unit
 

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -41,6 +41,37 @@ on:
         description: 'Whether to add the canonical test dirs (tests/( ,benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239).'
         default: false
         required: false
+      tests-osx-version:
+        type: string
+        description: 'The runner version for OSX: macos-*'
+        default: 'latest'
+        required: false
+      tests-win-version:
+        type: string
+        description: 'The runner version for Windows: windows-*'
+        default: 'latest'
+        required: false
+      tests-linux-version:
+        type: string
+        description: 'The runner version for Ubuntu: ubuntu-*'
+        default: 'latest'
+        required: false
+      tests-python-main:
+        type: string
+        description: 'The main version of python to test on, used across all three OS for tests and in other steps'
+        default: '3.11'
+        required: false
+      tests-python-alt1:
+        type: string
+        description: 'An alternate  version of python to test on, used only on linux'
+        default: '3.10'
+        required: false
+      tests-python-alt2:
+        type: string
+        description: 'An alternate  version of python to test on, used only on linux'
+        default: '3.9'
+        required: false
+
 
 jobs:
   commit-updated-env:  # Keep envs read by external sources (binder and readthedocs) up-to-date
@@ -78,9 +109,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pyiron/actions/build-docs@main
         with:
-          python-version: '3.11'
+          python-version: ${{ inputs.tests-python-main }}
           env-prefix: /usr/share/miniconda3/envs/my-env
-          env-label: linux-64-py-3-11
+          env-label: linux-64-py-main
           env-files: ${{ inputs.docs-env-files }}
 
   build-notebooks:
@@ -90,9 +121,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pyiron/actions/build-notebooks@main
         with:
-          python-version: '3.11'
+          python-version: ${{ inputs.tests-python-main }}
           env-prefix: /usr/share/miniconda3/envs/my-env
-          env-label: linux-64-py-3-11
+          env-label: linux-64-py-main
           env-files: ${{ inputs.notebooks-env-files }}
           exclusion-file: ${{ inputs.notebooks-exclusion-file }}
 
@@ -100,32 +131,34 @@ jobs:
   unit-tests:
     needs: commit-updated-env
     runs-on: ${{ matrix.operating-system }}
+    # OSX, Windows, and Ubuntu for the highest python version
+    # Ubuntu for up to two more versions of python
     strategy:
       matrix:
         include:
           - operating-system: macos-latest
-            python-version: '3.11'
-            label: osx-64-py-3-11
+            python-version: ${{ inputs.tests-python-main }}
+            label: osx-64-py-main
             prefix: /Users/runner/miniconda3/envs/my-env
 
           - operating-system: windows-latest
-            python-version: '3.11'
-            label: win-64-py-3-11
+            python-version: ${{ inputs.tests-python-main }}
+            label: win-64-py-main
             prefix: C:\Miniconda3\envs\my-env
 
           - operating-system: ubuntu-latest
-            python-version: '3.11'
-            label: linux-64-py-3-11
+            python-version: ${{ inputs.tests-python-main }}
+            label: linux-64-py-main
             prefix: /usr/share/miniconda3/envs/my-env
 
           - operating-system: ubuntu-latest
-            python-version: '3.10'
-            label: linux-64-py-3-10
+            python-version: ${{ inputs.tests-python-alt1 }}
+            label: linux-64-py-alt1
             prefix: /usr/share/miniconda3/envs/my-env
 
           - operating-system: ubuntu-latest
-            python-version: 3.9
-            label: linux-64-py-3-9
+            python-version: ${{ inputs.tests-python-alt2 }}
+            label: linux-64-py-alt2
             prefix: /usr/share/miniconda3/envs/my-env
 
     steps:
@@ -149,6 +182,7 @@ jobs:
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
       tests-in-python-path: ${{ inputs.tests-in-python-path }}
+      python-version: ${{ inputs.tests-python-main }}
 
   benchmark-tests:
     needs: commit-updated-env
@@ -157,9 +191,9 @@ jobs:
     - uses: actions/checkout@v3
     - uses: pyiron/actions/unit-tests@main
       with:
-        python-version: '3.11'
+        python-version: ${{ inputs.tests-python-main }}
         env-prefix: /usr/share/miniconda3/envs/my-env
-        env-label: linux-64-py-3-10
+        env-label: linux-64-py-main
         env-files: ${{ inputs.tests-env-files }}
         test-dir: tests/benchmark
       timeout-minutes: ${{ inputs.benchmark-timeout-minutes }}
@@ -171,9 +205,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pyiron/actions/pip-check@main
         with:
-          python-version: '3.11'
+          python-version: ${{ inputs.tests-python-main }}
           env-prefix: /usr/share/miniconda3/envs/my-env
-          env-label: linux-64-py-3-10
+          env-label: linux-64-py-main
 
   black:
     needs: commit-updated-env

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -140,29 +140,31 @@ jobs:
             python-version: ${{ inputs.python-version }}
             label: ${{ inputs.runner-alt2 }}-py-main
             prefix: /Users/runner/miniconda3/envs/my-env
+            do_run: ${{ inputs.runner-alt2 != 'exclude' }}
 
           - operating-system: ${{ inputs.runner-alt1 }}
             python-version: ${{ inputs.python-version }}
             label: ${{ inputs.runner-alt1 }}-py-main
             prefix: C:\Miniconda3\envs\my-env
+            do_run: ${{ inputs.runner-alt1 != 'exclude' }}
 
           - operating-system: ${{ inputs.runner }}
             python-version: ${{ inputs.python-version }}
             label: ${{ inputs.runner }}-py-main
             prefix: /usr/share/miniconda3/envs/my-env
+            do_run: true  # Always run the main runner with the main python version
 
           - operating-system: ${{ inputs.runner }}
             python-version: ${{ inputs.python-version-alt1 }}
             label: ${{ inputs.runner }}-py-alt1
             prefix: /usr/share/miniconda3/envs/my-env
+            do_run: ${{ inputs.python-version-alt1 != 'exclude' }}
 
           - operating-system: ${{ inputs.runner }}
             python-version: ${{ inputs.python-version-alt2 }}
             label: ${{ inputs.runner }}-py-alt2
             prefix: /usr/share/miniconda3/envs/my-env
-        exclude:
-          - operating-system: 'exclude'
-          - python-version: 'exclude'
+            do_run: ${{ inputs.python-version-alt2 != 'exclude' }}
 
     steps:
     - uses: actions/checkout@v3
@@ -171,6 +173,8 @@ jobs:
       with:
         path-dirs: tests tests/benchmark tests/integration tests/unit
     - uses: pyiron/actions/unit-tests@main
+      if: ${{ matrix.do_run }}
+      # It would be more elegant to skip earlier, but I'm not sure how to accomplish that
       with:
         python-version: ${{ matrix.python-version }}
         env-prefix: ${{ matrix.prefix }}

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -171,7 +171,7 @@ jobs:
 
   coveralls-and-codacy:
     needs: commit-updated-env
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@flexible_matrix
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@main
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -135,8 +135,8 @@ jobs:
     # Only the main for up to two more versions of python
     strategy:
       matrix:
-        operating-system: [${{ inputs.runner }}, ${{ inputs.runner-alt1 }}, ${{ inputs.runner-alt2 }}]
-        python-version: [${{ inputs.python-version }}, ${{ inputs.python-version-alt1 }}, ${{ inputs.python-version-alt2 }}]
+        operating-system: ["${{ inputs.runner }}", "${{ inputs.runner-alt1 }}", "${{ inputs.runner-alt2 }}"]
+        python-version: ["${{ inputs.python-version }}", "${{ inputs.python-version-alt1 }}", "${{ inputs.python-version-alt2 }}"]
         exclude:
           # Get rid of all combinations of alternative runners and alternative python versions
           - operating-system: ${{ inputs.runner-alt1 }}

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -41,20 +41,20 @@ on:
         description: 'Whether to add the canonical test dirs (tests/( ,benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239).'
         default: false
         required: false
-      tests-osx-version:
+      runner:
         type: string
-        description: 'The runner version for OSX: macos-*'
-        default: 'latest'
+        description: 'The main runner to use everywhere'
+        default: 'ubuntu-latest'
         required: false
-      tests-win-version:
+      runner-alt1:
         type: string
-        description: 'The runner version for Windows: windows-*'
-        default: 'latest'
+        description: 'An alternate runner for the unit tests (only on the main python version)'
+        default: 'windows-latest'
         required: false
-      tests-linux-version:
+      runner-alt2:
         type: string
-        description: 'The runner version for Ubuntu: ubuntu-*'
-        default: 'latest'
+        description: 'Another alternate runner for the unit tests (only on the main python version)'
+        default: 'macos-latest'
         required: false
       python-version:
         type: string
@@ -63,19 +63,19 @@ on:
         required: false
       python-version-alt1:
         type: string
-        description: 'An alternate  version of python to test on, used only on linux'
+        description: 'An alternate  version of python to run unit tests on, used only on the main runner'
         default: '3.10'
         required: false
       python-version-alt2:
         type: string
-        description: 'An alternate  version of python to test on, used only on linux'
+        description: 'An alternate  version of python to run unit tests on, used only on the main runner'
         default: '3.9'
         required: false
 
 
 jobs:
   commit-updated-env:  # Keep envs read by external sources (binder and readthedocs) up-to-date
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -104,26 +104,26 @@ jobs:
 
   build-docs:
     needs: commit-updated-env
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
       - uses: pyiron/actions/build-docs@main
         with:
           python-version: ${{ inputs.python-version }}
           env-prefix: /usr/share/miniconda3/envs/my-env
-          env-label: linux-64-py-main
+          env-label: ${{ inputs.runner }}-py-main
           env-files: ${{ inputs.docs-env-files }}
 
   build-notebooks:
     needs: commit-updated-env
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
       - uses: pyiron/actions/build-notebooks@main
         with:
           python-version: ${{ inputs.python-version }}
           env-prefix: /usr/share/miniconda3/envs/my-env
-          env-label: linux-64-py-main
+          env-label: ${{ inputs.runner }}-py-main
           env-files: ${{ inputs.notebooks-env-files }}
           exclusion-file: ${{ inputs.notebooks-exclusion-file }}
 
@@ -136,29 +136,29 @@ jobs:
     strategy:
       matrix:
         include:
-          - operating-system: macos-latest
+          - operating-system: ${{ inputs.runner-alt2 }}
             python-version: ${{ inputs.python-version }}
-            label: osx-64-py-main
+            label: ${{ inputs.runner-alt2 }}-py-main
             prefix: /Users/runner/miniconda3/envs/my-env
 
-          - operating-system: windows-latest
+          - operating-system: ${{ inputs.runner-alt1 }}
             python-version: ${{ inputs.python-version }}
-            label: win-64-py-main
+            label: ${{ inputs.runner-alt1 }}-py-main
             prefix: C:\Miniconda3\envs\my-env
 
-          - operating-system: ubuntu-latest
+          - operating-system: ${{ inputs.runner }}
             python-version: ${{ inputs.python-version }}
-            label: linux-64-py-main
+            label: ${{ inputs.runner }}-py-main
             prefix: /usr/share/miniconda3/envs/my-env
 
-          - operating-system: ubuntu-latest
+          - operating-system: ${{ inputs.runner }}
             python-version: ${{ inputs.python-version-alt1 }}
-            label: linux-64-py-alt1
+            label: ${{ inputs.runner }}-py-alt1
             prefix: /usr/share/miniconda3/envs/my-env
 
-          - operating-system: ubuntu-latest
+          - operating-system: ${{ inputs.runner }}
             python-version: ${{ inputs.python-version-alt2 }}
-            label: linux-64-py-alt2
+            label: ${{ inputs.runner }}-py-alt2
             prefix: /usr/share/miniconda3/envs/my-env
 
     steps:
@@ -182,36 +182,37 @@ jobs:
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
       tests-in-python-path: ${{ inputs.tests-in-python-path }}
+      runner: ${{ inputs.runner }}
       python-version: ${{ inputs.python-version }}
 
   benchmark-tests:
     needs: commit-updated-env
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v3
     - uses: pyiron/actions/unit-tests@main
       with:
         python-version: ${{ inputs.python-version }}
         env-prefix: /usr/share/miniconda3/envs/my-env
-        env-label: linux-64-py-main
+        env-label: ${{ inputs.runner }}-py-main
         env-files: ${{ inputs.tests-env-files }}
         test-dir: tests/benchmark
       timeout-minutes: ${{ inputs.benchmark-timeout-minutes }}
 
   pip-check:
     needs: commit-updated-env
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
       - uses: pyiron/actions/pip-check@main
         with:
           python-version: ${{ inputs.python-version }}
           env-prefix: /usr/share/miniconda3/envs/my-env
-          env-label: linux-64-py-main
+          env-label: ${{ inputs.runner }}-py-main
 
   black:
     needs: commit-updated-env
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
       - uses: psf/black@stable

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -164,7 +164,7 @@ jobs:
     - uses: pyiron/actions/unit-tests@main
       with:
         python-version: ${{ matrix.python-version }}
-        env-prefix: ${{ contains('macos', matrix.operating-system) && '/Users/runner/miniconda3/envs/my-env' || contains('windows', matrix.operating-system) && 'C:\Miniconda3\envs\my-env' || contains('ubuntu', matrix.operating-system) && '/usr/share/miniconda3/envs/my-env }}
+        env-prefix: ${{ contains('macos', matrix.operating-system) && '/Users/runner/miniconda3/envs/my-env' || contains('windows', matrix.operating-system) && 'C:\Miniconda3\envs\my-env' || contains('ubuntu', matrix.operating-system) && '/usr/share/miniconda3/envs/my-env' }}
         env-label: ${{ matrix.operating-system }}-py-${{ steps.vars.outputs.pyversion_string }}
         env-files: ${{ inputs.tests-env-files }}
         test-dir: tests/unit

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -48,12 +48,12 @@ on:
         required: false
       runner-alt1:
         type: string
-        description: 'An alternate runner for the unit tests (only on the main python version)'
+        description: 'An alternate runner for the unit tests (only on the main python version). Set to the string exclude to skip'
         default: 'windows-latest'
         required: false
       runner-alt2:
         type: string
-        description: 'Another alternate runner for the unit tests (only on the main python version)'
+        description: 'Another alternate runner for the unit tests (only on the main python version). Set to the string exclude to skip'
         default: 'macos-latest'
         required: false
       python-version:
@@ -63,12 +63,12 @@ on:
         required: false
       python-version-alt1:
         type: string
-        description: 'An alternate  version of python to run unit tests on, used only on the main runner'
+        description: 'An alternate  version of python to run unit tests on, used only on the main runner. Set to the string exclude to skip'
         default: '3.10'
         required: false
       python-version-alt2:
         type: string
-        description: 'An alternate  version of python to run unit tests on, used only on the main runner'
+        description: 'An alternate  version of python to run unit tests on, used only on the main runner. Set to the string exclude to skip'
         default: '3.9'
         required: false
 
@@ -160,6 +160,9 @@ jobs:
             python-version: ${{ inputs.python-version-alt2 }}
             label: ${{ inputs.runner }}-py-alt2
             prefix: /usr/share/miniconda3/envs/my-env
+        exclude:
+          operating-system: 'exclude'
+          python-version: 'exclude'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -131,8 +131,8 @@ jobs:
   unit-tests:
     needs: commit-updated-env
     runs-on: ${{ matrix.operating-system }}
-    # OSX, Windows, and Ubuntu for the highest python version
-    # Ubuntu for up to two more versions of python
+    # All three runners for the highest python version
+    # Only the main for up to two more versions of python
     strategy:
       matrix:
         include:

--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -161,8 +161,8 @@ jobs:
             label: ${{ inputs.runner }}-py-alt2
             prefix: /usr/share/miniconda3/envs/my-env
         exclude:
-          operating-system: 'exclude'
-          python-version: 'exclude'
+          - operating-system: 'exclude'
+          - python-version: 'exclude'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -23,6 +23,11 @@ on:
         description: 'Whether to add the canonical test dirs (tests/( ,benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239).'
         default: false
         required: false
+      runner:
+        type: string
+        description: 'The main runner to use everywhere'
+        default: 'ubuntu-latest'
+        required: false
       python-version:
         type: string
         description: 'The version of python use'
@@ -31,7 +36,7 @@ on:
 
 jobs:
   Tests-and-Coverage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
       - uses: pyiron/actions/add-to-python-path@main

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -23,6 +23,11 @@ on:
         description: 'Whether to add the canonical test dirs (tests/( ,benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239).'
         default: false
         required: false
+      python-version:
+        type: string
+        description: 'The version of python use'
+        default: '3.11'
+        required: false
 
 jobs:
   Tests-and-Coverage:
@@ -35,9 +40,9 @@ jobs:
           path-dirs: tests tests/benchmark tests/integration tests/unit
       - uses: pyiron/actions/unit-tests@main
         with:
-          python-version: '3.11'
+          python-version: ${{ inputs.python-version }}
           env-prefix: /usr/share/miniconda3/envs/my-env
-          env-label: linux-64-py-3-10
+          env-label: linux-64-py
           env-files: ${{ inputs.tests-env-files }}
           test-dir: tests
       - name: Coverage


### PR DESCRIPTION
I'm being pretty bold with the syntax here, so we'll see if it works.

The idea is to let the reusable workflow caller specify which versions of the OS and python they want to use. This becomes important for packages relying on `pympipool`, since OSX >11 is not playing nicely with MPI right now.

EDIT:

Ok, it's all working when tested over in [`pyiron_workflow`](https://github.com/pyiron/pyiron_workflow/pull/108).

This PR exposes python version and runners as optional input to two of the reusable workflows, and reformulates the unit test matrix to use them. In particular, we now have a primary runner and python version, and two alternate versions of each. By default this is just the standard (ubuntu-latest, 3.11), and (windows-latest, macos-latest) and (3.10 and 3.9). Without any input from the user, we do the same operations as before where the alternate OSs get run on the main version of python while the main OS gets (additionally) run on the alternate versions of python.

In addition to being able to specify particular runner and python versions, the "alternates" can take the value `'exclude'` and these are entirely removed from the unit test matrix! This is accomplished by switching from a `include:` paradigm to a full (multiplicative) matrix + `exclude:` conditions.

@niklassiemer (and anyone else who's interested), since this (a) only touches the reusable workflows and not the actions, (b) is working fine in practice, and (c) maintains the old default behaviour, I'll probably merge it without review so I can keep rolling on `pyiron_workflow`. However, a post-facto review to improve readability etc. is of course always welcome!!!