### PR TITLE
Include myst-parser, sphinx-gallery, and the rtd theme in the base docs environment

### DIFF
--- a/.support/environment-docs.yml
+++ b/.support/environment-docs.yml
@@ -2,6 +2,6 @@ channels:
   - conda-forge
 dependencies:
   - ipykernel
-  - nbsphinx
   - myst-parser
+  - nbsphinx
   - sphinx-gallery

--- a/.support/environment-docs.yml
+++ b/.support/environment-docs.yml
@@ -4,3 +4,4 @@ dependencies:
   - ipykernel
   - nbsphinx
   - myst-parser
+  - sphinx-gallery

--- a/.support/environment-docs.yml
+++ b/.support/environment-docs.yml
@@ -3,4 +3,4 @@ channels:
 dependencies:
   - ipykernel
   - nbsphinx
-  - myst
+  - myst-parser

--- a/.support/environment-docs.yml
+++ b/.support/environment-docs.yml
@@ -3,3 +3,4 @@ channels:
 dependencies:
   - ipykernel
   - nbsphinx
+  - myst

--- a/.support/environment-docs.yml
+++ b/.support/environment-docs.yml
@@ -5,3 +5,4 @@ dependencies:
   - myst-parser
   - nbsphinx
   - sphinx-gallery
+  - sphinx-rtd-theme

--- a/write-docs-env/action.yaml
+++ b/write-docs-env/action.yaml
@@ -7,7 +7,7 @@ inputs:
     default: .ci_support/environment.yml
     required: false
   standard-docs-env-file:
-    description: 'Env files this action thinks are useful (adds nbsphinx package)'
+    description: 'Env files this action thinks are useful (adds nbsphinx and other packages)'
     default: $GITHUB_ACTION_PATH/../.support/environment-docs.yml
     required: false
   output-env-file:


### PR DESCRIPTION
This includes `myst-parser` (along with the existing `ipykernel` and `nbsphinx`) into the environment for all invocations of the `build-docs` action unless the [`standard-docs-env-file`](https://github.com/pyiron/actions/blob/7b7eff54a5c35f63e4d5f2782cc766e31be2580d/build-docs/action.yml#L18) is overridden at call time.

Pros: This package is necessary for parsing `.md` files in the sphinx docs, and so is super useful when the `README.md` lives in `docs/` and gets used for the readthedocs landing page -- as I've already done for `pyiron_workflow` and am now doing [in this PR](https://github.com/pyiron/pyiron_module_template/pull/20) for `pyiron_module_template`.

Cons: bloats the docs env in case someone _doesn't_ need `myst-parser`. @jan-janssen, I see you have it in `pyiron/atomistics` as well, and not for the sake of using the README as the docs landing, so perhaps it is pretty generically useful and this is not such a con?