### PR TITLE
Add h5io browser to pypi conda mapping

### DIFF
--- a/.support/pypi_vs_conda_names.json
+++ b/.support/pypi_vs_conda_names.json
@@ -6,5 +6,6 @@
   "pyiron-experimental": "pyiron_experimental",
   "pyiron-continuum": "pyiron_continuum",
   "pyiron-gpl": "pyiron_gpl",
-  "pyiron-gui": "pyiron_gui"
+  "pyiron-gui": "pyiron_gui",
+  "h5io-browser": "h5io_browser"
 }


### PR DESCRIPTION
This fixes the issue I mentioned at the end of the pyiron meeting.  Just a matter of the pypi/conda names not lining up.