### PR TITLE
[patch] Add versioneer dependency

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
-      - uses: pyiron/actions/update-env-files@main
+      - uses: pyiron/actions/update-env-files@add_versioneer_dependency
       - name: UpdateDependabotPR commit
         run: |
           git config --local user.email "pyiron@mpie.de"

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -43,10 +43,10 @@ jobs:
 
   tests-and-coverage:
     if: contains(github.event.pull_request.labels.*.name, 'run_coverage')
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@main
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@add_versioneer_dependency
     secrets: inherit
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'run_CodeQL')
-    uses: pyiron/actions/.github/workflows/codeql.yml@main
+    uses: pyiron/actions/.github/workflows/codeql.yml@add_versioneer_dependency
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -87,10 +87,10 @@ jobs:
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
-      - uses: pyiron/actions/write-docs-env@main
+      - uses: pyiron/actions/write-docs-env@add_versioneer_dependency
         with:
           env-files: ${{ inputs.docs-env-files }}
-      - uses: pyiron/actions/write-environment@main
+      - uses: pyiron/actions/write-environment@add_versioneer_dependency
         with:
           env-files: ${{ inputs.notebooks-env-files }}
           output-env-file: .binder/environment.yml
@@ -114,7 +114,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
-      - uses: pyiron/actions/build-docs@main
+      - uses: pyiron/actions/build-docs@add_versioneer_dependency
         with:
           python-version: ${{ inputs.python-version }}
           env-prefix: /usr/share/miniconda3/envs/my-env
@@ -126,7 +126,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
-      - uses: pyiron/actions/build-notebooks@main
+      - uses: pyiron/actions/build-notebooks@add_versioneer_dependency
         with:
           python-version: ${{ inputs.python-version }}
           env-prefix: /usr/share/miniconda3/envs/my-env
@@ -164,7 +164,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: pyiron/actions/add-to-python-path@main
+    - uses: pyiron/actions/add-to-python-path@add_versioneer_dependency
       if: ${{ inputs.tests-in-python-path }}
       with:
         path-dirs: tests tests/benchmark tests/integration tests/unit
@@ -184,7 +184,7 @@ jobs:
         elif [[ ${os_string} == "ubuntu-"* ]]; then
           echo "env_prefix_string=/usr/share/miniconda3/envs/my-env" >> $GITHUB_OUTPUT
         fi
-    - uses: pyiron/actions/unit-tests@main
+    - uses: pyiron/actions/unit-tests@add_versioneer_dependency
       with:
         python-version: ${{ matrix.python-version }}
         env-prefix: ${{ steps.determine_conda_prefix.outputs.env_prefix_string }}
@@ -194,7 +194,7 @@ jobs:
 
   coveralls-and-codacy:
     needs: commit-updated-env
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@main
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@add_versioneer_dependency
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
@@ -207,7 +207,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v3
-    - uses: pyiron/actions/unit-tests@main
+    - uses: pyiron/actions/unit-tests@add_versioneer_dependency
       with:
         python-version: ${{ inputs.python-version }}
         env-prefix: /usr/share/miniconda3/envs/my-env
@@ -221,7 +221,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
-      - uses: pyiron/actions/pip-check@main
+      - uses: pyiron/actions/pip-check@add_versioneer_dependency
         with:
           python-version: ${{ inputs.python-version }}
           env-prefix: /usr/share/miniconda3/envs/my-env

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
-      - uses: pyiron/actions/add-to-python-path@main
+      - uses: pyiron/actions/add-to-python-path@add_versioneer_dependency
         if: ${{ inputs.tests-in-python-path }}
         with:
           path-dirs: tests tests/benchmark tests/integration tests/unit
@@ -59,7 +59,7 @@ jobs:
           elif [[ ${os_string} == "ubuntu-"* ]]; then
             echo "env_prefix_string=/usr/share/miniconda3/envs/my-env" >> $GITHUB_OUTPUT
           fi
-      - uses: pyiron/actions/unit-tests@main
+      - uses: pyiron/actions/unit-tests@add_versioneer_dependency
         with:
           python-version: ${{ inputs.python-version }}
           env-prefix: ${{ steps.determine_conda_prefix.outputs.env_prefix_string }}

--- a/.support/environment-docs.yml
+++ b/.support/environment-docs.yml
@@ -6,3 +6,4 @@ dependencies:
   - nbsphinx
   - sphinx-gallery
   - sphinx-rtd-theme
+  - versioneer

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@main
+    uses: pyiron/actions/.github/workflows/push-pull.yml@add_versioneer_dependency
     secrets: inherit
 ```
 

--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -27,13 +27,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-mamba@main
+  - uses: pyiron/actions/cached-mamba@add_versioneer_dependency
     with:
       python-version: ${{ inputs.python-version }}
       env-prefix: ${{ inputs.env-prefix }}
       env-label: ${{ inputs.env-label }}
       env-files: ${{ inputs.standard-docs-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@main
+  - uses: pyiron/actions/pyiron-config@add_versioneer_dependency
   - name: Build sphinx documentation
     shell: bash -l {0}
     run: |

--- a/build-notebooks/action.yml
+++ b/build-notebooks/action.yml
@@ -30,13 +30,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-mamba@main
+  - uses: pyiron/actions/cached-mamba@add_versioneer_dependency
     with:
       python-version: ${{ inputs.python-version }}
       env-prefix: ${{ inputs.env-prefix }}
       env-label: ${{ inputs.env-label }}
       env-files: ${{ inputs.standard-notebooks-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@main
+  - uses: pyiron/actions/pyiron-config@add_versioneer_dependency
   - name: Build notebooks
     shell: bash -l {0}
     run: $GITHUB_ACTION_PATH/../.support/build_notebooks.sh ${{ inputs.notebooks-dir }} ${{ inputs.exclusion-file }}

--- a/cached-mamba/action.yml
+++ b/cached-mamba/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: pyiron/actions/write-environment@main
+  - uses: pyiron/actions/write-environment@add_versioneer_dependency
     with:
       env-files: ${{ inputs.env-files }}
   - name: Setup Mambaforge

--- a/pip-check/action.yml
+++ b/pip-check/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-mamba@main
+  - uses: pyiron/actions/cached-mamba@add_versioneer_dependency
     with:
       python-version: ${{ inputs.python-version }}
       env-prefix: ${{ inputs.env-prefix }}

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -38,13 +38,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-mamba@main
+  - uses: pyiron/actions/cached-mamba@add_versioneer_dependency
     with:
       python-version: ${{ inputs.python-version }}
       env-prefix: ${{ inputs.env-prefix }}
       env-label: ${{ inputs.env-label }}
       env-files: ${{ inputs.standard-unittests-env-file }} ${{ inputs.coveralls-codacy-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@main
+  - uses: pyiron/actions/pyiron-config@add_versioneer_dependency
   - name: Test
     shell: bash -l {0}
     run: |


### PR DESCRIPTION
When I switched over to pyproject.toml and got rid of the local `versioneer.py` file in https://github.com/pyiron/pyiron_ontology/pull/51, the docs failed to build because `conf.py` couldn't run `versioneer.get_version()` anymore. This fixed that.