### PR TITLE
[minor] change default semantic upper limit

### DIFF
--- a/update-pyproject-dependencies/action.yml
+++ b/update-pyproject-dependencies/action.yml
@@ -20,7 +20,7 @@ inputs:
   semantic-upper-bound:
     type: string
     description: 'Upper bound policy for semantically versioned dependencies.'
-    default: 'patch'
+    default: 'minor'
     required: false
   always-pin-unstable:
     type: string


### PR DESCRIPTION
By default, free the patch version on semantically versioned dependencies in `update-pyproject-dependencies`. Unstable (0.Y.Z) projects still get pinned to the patch by default.

This would be a breaking change if there were users depending on this default, but there most certainly are not so minor is sufficient.