### PR TITLE
[patch] Extend pypi2conda map

### DIFF
--- a/.support/pypi_vs_conda_names.json
+++ b/.support/pypi_vs_conda_names.json
@@ -1,11 +1,11 @@
 {
-  "tables": "pytables",
-  "pyiron-base": "pyiron_base",
+  "h5io-browser": "h5io_browser",
   "pyiron-atomistics": "pyiron_atomistics",
+  "pyiron-base": "pyiron_base",
+  "pyiron-continuum": "pyiron_continuum",
   "pyiron-contrib": "pyiron_contrib",
   "pyiron-experimental": "pyiron_experimental",
-  "pyiron-continuum": "pyiron_continuum",
   "pyiron-gpl": "pyiron_gpl",
   "pyiron-gui": "pyiron_gui",
-  "h5io-browser": "h5io_browser"
+  "tables": "pytables"
 }

--- a/.support/pypi_vs_conda_names.json
+++ b/.support/pypi_vs_conda_names.json
@@ -1,4 +1,5 @@
 {
+  "blosc2": "python-blosc2",
   "h5io-browser": "h5io_browser",
   "pyiron-atomistics": "pyiron_atomistics",
   "pyiron-base": "pyiron_base",

--- a/.support/pypi_vs_conda_names.json
+++ b/.support/pypi_vs_conda_names.json
@@ -1,6 +1,7 @@
 {
   "blosc2": "python-blosc2",
   "h5io-browser": "h5io_browser",
+  "matplotlib": "matplotlib-base",
   "pyiron-atomistics": "pyiron_atomistics",
   "pyiron-base": "pyiron_base",
   "pyiron-continuum": "pyiron_continuum",

--- a/.support/pypi_vs_conda_names.json
+++ b/.support/pypi_vs_conda_names.json
@@ -9,5 +9,7 @@
   "pyiron-experimental": "pyiron_experimental",
   "pyiron-gpl": "pyiron_gpl",
   "pyiron-gui": "pyiron_gui",
+  "pyiron-ontology": "pyiron_ontology",
+  "pyiron-workflow": "pyiron_workflow",
   "tables": "pytables"
 }


### PR DESCRIPTION
In the pyproject version releaser, I guess it will be possible to try with a `.replace("-", "_")` since pip in general uses "-" in place of "_". However, we can't just uniformly do that in the environment updater as there are legit conda packages that will allow "-". For now, I just extend the whitelist of (pyiron) packages where we know the conda version is "_"