### PR TITLE
[major] Change python path input from a bool to a variable

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
-      - uses: pyiron/actions/update-env-files@main
+      - uses: pyiron/actions/update-env-files@free_python_path
       - name: UpdateDependabotPR commit
         run: |
           git config --local user.email "pyiron@mpie.de"

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -43,10 +43,10 @@ jobs:
 
   tests-and-coverage:
     if: contains(github.event.pull_request.labels.*.name, 'run_coverage')
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@main
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@free_python_path
     secrets: inherit
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'run_CodeQL')
-    uses: pyiron/actions/.github/workflows/codeql.yml@main
+    uses: pyiron/actions/.github/workflows/codeql.yml@free_python_path
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -92,7 +92,7 @@ on:
         default: 30
         required: false
       extra-python-paths:
-        type: str
+        type: string
         description: 'Extra paths (e.g. test dirs tests/(benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239) -- currently only seems to be an issue on windows?'
         default: ''
         required: false

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -91,10 +91,10 @@ on:
         description: 'How many minutes to allow tests in units/benchmark to run for'
         default: 30
         required: false
-      tests-in-python-path:
-        type: boolean
-        description: 'Whether to add the canonical test dirs (tests/( ,benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239).'
-        default: false
+      extra-python-paths:
+        type: str
+        description: 'Extra paths (e.g. test dirs tests/(benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239) -- currently only seems to be an issue on windows?'
+        default: ''
         required: false
       runner:
         type: string
@@ -257,9 +257,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: pyiron/actions/add-to-python-path@free_python_path
-      if: ${{ inputs.tests-in-python-path }}
+      if: inputs.extra-python-paths != ""
       with:
-        path-dirs: ${{ inputs.unit-test-dir }}
+        path-dirs: ${{ inputs.extra-python-paths }}
     - uses: pyiron/actions/unit-tests@free_python_path
       with:
         python-version: ${{ matrix.python-version }}
@@ -275,7 +275,7 @@ jobs:
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
-      tests-in-python-path: ${{ inputs.tests-in-python-path }}
+      extra-python-paths: ${{ inputs.extra-python-paths }}
       runner: ${{ inputs.runner }}
       python-version: ${{ inputs.python-version }}
       test-dir: ${{ inputs.coveralls-and-codacy-test-dir }}

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -257,7 +257,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: pyiron/actions/add-to-python-path@free_python_path
-      if: inputs.extra-python-paths != ""
+      if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
     - uses: pyiron/actions/unit-tests@free_python_path

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -177,11 +177,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-docs-env@main
+      - uses: pyiron/actions/write-docs-env@free_python_path
         with:
           env-files: ${{ inputs.docs-env-files }}
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-environment@main
+      - uses: pyiron/actions/write-environment@free_python_path
         with:
           env-files: ${{ inputs.notebooks-env-files }}
           output-env-file: .binder/environment.yml
@@ -208,7 +208,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-docs@main
+      - uses: pyiron/actions/build-docs@free_python_path
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.docs-env-files }}
@@ -219,7 +219,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-notebooks@main
+      - uses: pyiron/actions/build-notebooks@free_python_path
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.notebooks-env-files }}
@@ -256,11 +256,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@main
+    - uses: pyiron/actions/add-to-python-path@free_python_path
       if: ${{ inputs.tests-in-python-path }}
       with:
         path-dirs: ${{ inputs.unit-test-dir }}
-    - uses: pyiron/actions/unit-tests@main
+    - uses: pyiron/actions/unit-tests@free_python_path
       with:
         python-version: ${{ matrix.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -271,7 +271,7 @@ jobs:
   coveralls-and-codacy:
     needs: commit-updated-env
     if: ${{ inputs.do-coveralls || inputs.do-codacy }}
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@main
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@free_python_path
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
@@ -290,7 +290,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/unit-tests@main
+    - uses: pyiron/actions/unit-tests@free_python_path
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -303,7 +303,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/unit-tests@main
+    - uses: pyiron/actions/unit-tests@free_python_path
       with:
         python-version: ${{ inputs.alternate-tests-python-version }}
         env-files: ${{ inputs.alternate-tests-env-files }}
@@ -316,7 +316,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/pip-check@main
+      - uses: pyiron/actions/pip-check@free_python_path
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -93,7 +93,7 @@ on:
         required: false
       extra-python-paths:
         type: string
-        description: 'Extra paths (e.g. test dirs tests/(benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239) -- currently only seems to be an issue on windows?'
+        description: 'Extra paths (e.g. test dirs tests/(benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239).'
         default: ''
         required: false
       runner:

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -74,11 +74,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/cached-miniforge@main
+    - uses: pyiron/actions/cached-miniforge@free_python_path
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@main
+    - uses: pyiron/actions/update-pyproject-dependencies@free_python_path
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -64,11 +64,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@main
+      - uses: pyiron/actions/add-to-python-path@free_python_path
         if: ${{ inputs.tests-in-python-path }}
         with:
           path-dirs: ${{ inputs.test-dir }}
-      - uses: pyiron/actions/unit-tests@main
+      - uses: pyiron/actions/unit-tests@free_python_path
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.tests-env-files }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -29,7 +29,7 @@ on:
         default: .ci_support/environment.yml
         required: false
       extra-python-paths:
-        type: str
+        type: string
         description: 'Extra paths (e.g. test dirs tests/(benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239) -- currently only seems to be an issue on windows?'
         default: ''
         required: false

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -28,10 +28,10 @@ on:
         description: 'Paths to an arbitrary number of (space-separated) conda environment yaml files'
         default: .ci_support/environment.yml
         required: false
-      tests-in-python-path:
-        type: boolean
-        description: 'Whether to add the canonical test dirs (tests/( ,benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239).'
-        default: false
+      extra-python-paths:
+        type: str
+        description: 'Extra paths (e.g. test dirs tests/(benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239) -- currently only seems to be an issue on windows?'
+        default: ''
         required: false
       runner:
         type: string
@@ -65,9 +65,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pyiron/actions/add-to-python-path@free_python_path
-        if: ${{ inputs.tests-in-python-path }}
+        if: inputs.extra-python-paths != ''
         with:
-          path-dirs: ${{ inputs.test-dir }}
+          path-dirs: ${{ inputs.extra-python-paths }}
       - uses: pyiron/actions/unit-tests@free_python_path
         with:
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -30,7 +30,7 @@ on:
         required: false
       extra-python-paths:
         type: string
-        description: 'Extra paths (e.g. test dirs tests/(benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239) -- currently only seems to be an issue on windows?'
+        description: 'Extra paths (e.g. test dirs tests/(benchmark,integration,unit)) to the PYTHONPATH. This is a required workaround for repos that use `pympipool` executors, [cf. this issue](https://github.com/pyiron/pympipool/issues/239).'
         default: ''
         required: false
       runner:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@main
+    uses: pyiron/actions/.github/workflows/push-pull.yml@free_python_path
     secrets: inherit
 ```
 

--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -21,11 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@main
+  - uses: pyiron/actions/cached-miniforge@free_python_path
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-docs-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@main
+  - uses: pyiron/actions/pyiron-config@free_python_path
   - name: Build sphinx documentation
     shell: bash -l {0}
     run: |

--- a/build-notebooks/action.yml
+++ b/build-notebooks/action.yml
@@ -24,11 +24,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@main
+  - uses: pyiron/actions/cached-miniforge@free_python_path
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-notebooks-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@main
+  - uses: pyiron/actions/pyiron-config@free_python_path
   - name: Build notebooks
     shell: bash -l {0}
     run: $GITHUB_ACTION_PATH/../.support/build_notebooks.sh ${{ inputs.notebooks-dir }} ${{ inputs.exclusion-file }}

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -53,7 +53,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: pyiron/actions/write-environment@main
+  - uses: pyiron/actions/write-environment@free_python_path
     with:
       env-files: ${{ inputs.env-files }}
   - name: Setup Mambaforge

--- a/pip-check/action.yml
+++ b/pip-check/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@main
+  - uses: pyiron/actions/cached-miniforge@free_python_path
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.env-files }}

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -35,11 +35,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@main
+  - uses: pyiron/actions/cached-miniforge@free_python_path
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-unittests-env-file }} ${{ inputs.coveralls-codacy-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@main
+  - uses: pyiron/actions/pyiron-config@free_python_path
   - name: Test
     shell: bash -l {0}
     run: |


### PR DESCRIPTION
So you can target something other than the tests directory; necessary when the tests are found recursively and you want to add sub-folders to the path.

Changes the workflow interface, so major.