### PR TITLE
install pyyaml via apt

### DIFF
--- a/write-environment/action.yml
+++ b/write-environment/action.yml
@@ -16,7 +16,7 @@ runs:
   - name: Ensure yaml module is present
     # Ubuntu works fine, but both windows and macos wind up complaining that there is no module "yaml"
     shell: bash -l {0}
-    run: pip install pyyaml
+    run: apt install python3-yaml
   - name: Write environment
     shell: bash -l {0}
     run: |

--- a/write-environment/action.yml
+++ b/write-environment/action.yml
@@ -16,7 +16,7 @@ runs:
   - name: Ensure yaml module is present
     # Ubuntu works fine, but both windows and macos wind up complaining that there is no module "yaml"
     shell: bash -l {0}
-    run: apt install python3-yaml
+    run: pip install pyyaml
   - name: Write environment
     shell: bash -l {0}
     run: |


### PR DESCRIPTION
See title. Somehow, the runner-os complains when trying to use `pip install pyyaml`. So I replaced this by `apt install python3-yaml`. See also [here](https://github.com/pyiron/uniton/pull/11#issuecomment-2414207685)