### PR TITLE
[major] run black on the whole repository

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -344,4 +344,3 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --diff"
-          src: ./${{ github.event.repository.name }}


### PR DESCRIPTION
Formatting the whole repository should be the default. Exclusion of files and directories should be the exception. Not the other way round. Files and directories can be excluded via `pyproject.toml`:
```
[tool.black]
extend-exclude = ''' 
(
  ^/docs
)
'''