### PR TITLE
[major] Make the ruff checks happen by default

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -59,12 +59,12 @@ on:
       do-ruff-check:
         type: boolean
         description: 'Feature flag: controls if the ruff check job runs.'
-        default: false
+        default: true
         required: false
       do-ruff-sort-imports:
         type: boolean
         description: 'Feature flag: controls if the ruff import sorting job runs.'
-        default: false
+        default: true
         required: false
       docs-env-files:
         type: string


### PR DESCRIPTION
Honestly, I don't remember for sure whether the custom workflows in `.github/` were part of the API or not, but having this default on would cause a bunch of repos to start failing if they target it, so for now I'm flagging it "major".