### PR TITLE
[minor] Change codacy to default off

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -39,7 +39,7 @@ on:
       do-codacy:
         type: boolean
         description: 'Whether to push the report to codacy after generating coverage. If neither do-coveralls nor do-codacy are true, the coveralls-and-codacy job is skipped.'
-        default: true
+        default: false
         required: false
       do-benchmark-tests:
         type: boolean

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -56,7 +56,7 @@ on:
       do-codacy:
         type: boolean
         description: 'Whether to push the report to codacy after generating coverage'
-        default: true
+        default: false
         required: false
 
 jobs:


### PR DESCRIPTION
With ruff and black across the whole repo (excl. docs) by default in the next actions release, I don't see a need to keep running codacy. From what I understand it may be useful if we want to apply additional screenings for things like cryptographic or license compliance, but we're not really leveraging any of that afaik. I'm happy to keep the functionality available, but I'm inclined to make it on-request instead of always there.

Thoughts?