### PR TITLE
[major] Updates to cached-miniforge

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
-      - uses: pyiron/actions/update-env-files@use_miniconda
+      - uses: pyiron/actions/update-env-files@actions-4.0.0
       - name: UpdateDependabotPR commit
         run: |
           git config --local user.email "pyiron@mpie.de"

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
-      - uses: pyiron/actions/update-env-files@v3.3.2
+      - uses: pyiron/actions/update-env-files@use_miniconda
       - name: UpdateDependabotPR commit
         run: |
           git config --local user.email "pyiron@mpie.de"

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -48,10 +48,10 @@ jobs:
 
   tests-and-coverage:
     if: contains(github.event.pull_request.labels.*.name, 'run_coverage')
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@v3.3.2
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@use_miniconda
     secrets: inherit
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'run_CodeQL')
-    uses: pyiron/actions/.github/workflows/codeql.yml@v3.3.2
+    uses: pyiron/actions/.github/workflows/codeql.yml@use_miniconda
     secrets: inherit

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -48,10 +48,10 @@ jobs:
 
   tests-and-coverage:
     if: contains(github.event.pull_request.labels.*.name, 'run_coverage')
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@use_miniconda
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.0
     secrets: inherit
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'run_CodeQL')
-    uses: pyiron/actions/.github/workflows/codeql.yml@use_miniconda
+    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.0
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -197,11 +197,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-docs-env@use_miniconda
+      - uses: pyiron/actions/write-docs-env@actions-4.0.0
         with:
           env-files: ${{ inputs.docs-env-files }}
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-environment@use_miniconda
+      - uses: pyiron/actions/write-environment@actions-4.0.0
         with:
           env-files: ${{ inputs.notebooks-env-files }}
           output-env-file: .binder/environment.yml
@@ -228,7 +228,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-docs@use_miniconda
+      - uses: pyiron/actions/build-docs@actions-4.0.0
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.docs-env-files }}
@@ -239,7 +239,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-notebooks@use_miniconda
+      - uses: pyiron/actions/build-notebooks@actions-4.0.0
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.notebooks-env-files }}
@@ -276,11 +276,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@use_miniconda
+    - uses: pyiron/actions/add-to-python-path@actions-4.0.0
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@use_miniconda
+    - uses: pyiron/actions/unit-tests@actions-4.0.0
       with:
         python-version: ${{ matrix.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -291,7 +291,7 @@ jobs:
   coveralls-and-codacy:
     needs: commit-updated-env
     if: ${{ inputs.do-coveralls || inputs.do-codacy }}
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@use_miniconda
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.0
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
@@ -310,7 +310,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/unit-tests@use_miniconda
+    - uses: pyiron/actions/unit-tests@actions-4.0.0
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -323,11 +323,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@use_miniconda
+    - uses: pyiron/actions/add-to-python-path@actions-4.0.0
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@use_miniconda
+    - uses: pyiron/actions/unit-tests@actions-4.0.0
       with:
         python-version: ${{ inputs.alternate-tests-python-version }}
         env-files: ${{ inputs.alternate-tests-env-files }}
@@ -341,7 +341,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/pip-check@use_miniconda
+      - uses: pyiron/actions/pip-check@actions-4.0.0
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -197,11 +197,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-docs-env@v3.3.2
+      - uses: pyiron/actions/write-docs-env@use_miniconda
         with:
           env-files: ${{ inputs.docs-env-files }}
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-environment@v3.3.2
+      - uses: pyiron/actions/write-environment@use_miniconda
         with:
           env-files: ${{ inputs.notebooks-env-files }}
           output-env-file: .binder/environment.yml
@@ -228,7 +228,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-docs@v3.3.2
+      - uses: pyiron/actions/build-docs@use_miniconda
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.docs-env-files }}
@@ -239,7 +239,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-notebooks@v3.3.2
+      - uses: pyiron/actions/build-notebooks@use_miniconda
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.notebooks-env-files }}
@@ -276,11 +276,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@v3.3.2
+    - uses: pyiron/actions/add-to-python-path@use_miniconda
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@v3.3.2
+    - uses: pyiron/actions/unit-tests@use_miniconda
       with:
         python-version: ${{ matrix.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -291,7 +291,7 @@ jobs:
   coveralls-and-codacy:
     needs: commit-updated-env
     if: ${{ inputs.do-coveralls || inputs.do-codacy }}
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@v3.3.2
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@use_miniconda
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
@@ -310,7 +310,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/unit-tests@v3.3.2
+    - uses: pyiron/actions/unit-tests@use_miniconda
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -323,11 +323,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@v3.3.2
+    - uses: pyiron/actions/add-to-python-path@use_miniconda
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@v3.3.2
+    - uses: pyiron/actions/unit-tests@use_miniconda
       with:
         python-version: ${{ inputs.alternate-tests-python-version }}
         env-files: ${{ inputs.alternate-tests-env-files }}
@@ -341,7 +341,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/pip-check@v3.3.2
+      - uses: pyiron/actions/pip-check@use_miniconda
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -83,11 +83,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/cached-miniforge@use_miniconda
+    - uses: pyiron/actions/cached-miniforge@actions-4.0.0
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@use_miniconda
+    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.0
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -14,7 +14,7 @@ on:
     inputs:
       python-version:
         type: string
-        description: 'Cached mamba python versions'
+        description: 'Cached python versions'
         default: '3.12'
         required: false
       env-files:

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -83,11 +83,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/cached-miniforge@v3.3.2
+    - uses: pyiron/actions/cached-miniforge@use_miniconda
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@v3.3.2
+    - uses: pyiron/actions/update-pyproject-dependencies@use_miniconda
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -64,11 +64,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@v3.3.2
+      - uses: pyiron/actions/add-to-python-path@use_miniconda
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/unit-tests@v3.3.2
+      - uses: pyiron/actions/unit-tests@use_miniconda
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.tests-env-files }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -64,11 +64,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@use_miniconda
+      - uses: pyiron/actions/add-to-python-path@actions-4.0.0
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/unit-tests@use_miniconda
+      - uses: pyiron/actions/unit-tests@actions-4.0.0
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.tests-env-files }}

--- a/.support/update_actions_tag.sh
+++ b/.support/update_actions_tag.sh
@@ -12,5 +12,11 @@
 # Set default value for $1 if not provided
 PATTERN=${1:-$(git rev-parse --abbrev-ref HEAD)}
 
-# Recursive search and replace
-find . -type f \( -name "*.yml" -o -name "*.md" \) -exec sed -i 's/\(pyiron\/actions\/[^@]*\)@[^*]*/\1@'"$PATTERN"'/g' {} +
+# Check if we're on macOS or Linux and use appropriate sed syntax
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS version
+    find . -type f \( -name "*.yml" -o -name "*.md" \) -exec sed -i '' 's/\(pyiron\/actions\/[^@]*\)@[^*]*/\1@'"$PATTERN"'/g' {} +
+else
+    # Linux version (and others)
+    find . -type f \( -name "*.yml" -o -name "*.md" \) -exec sed -i 's/\(pyiron\/actions\/[^@]*\)@[^*]*/\1@'"$PATTERN"'/g' {} +
+fi

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@use_miniconda
+    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.0
     secrets: inherit
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@v3.3.2
+    uses: pyiron/actions/.github/workflows/push-pull.yml@use_miniconda
     secrets: inherit
 ```
 

--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -21,11 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@use_miniconda
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.0
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-docs-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@use_miniconda
+  - uses: pyiron/actions/pyiron-config@actions-4.0.0
   - name: Build sphinx documentation
     shell: bash -l {0}
     run: |

--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -21,11 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@v3.3.2
+  - uses: pyiron/actions/cached-miniforge@use_miniconda
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-docs-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@v3.3.2
+  - uses: pyiron/actions/pyiron-config@use_miniconda
   - name: Build sphinx documentation
     shell: bash -l {0}
     run: |

--- a/build-notebooks/action.yml
+++ b/build-notebooks/action.yml
@@ -28,11 +28,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@use_miniconda
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.0
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-notebooks-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@use_miniconda
+  - uses: pyiron/actions/pyiron-config@actions-4.0.0
   - name: Build notebooks
     shell: bash -l {0}
     run: $GITHUB_ACTION_PATH/../.support/build_notebooks.sh ${{ inputs.notebooks-dir }} ${{ inputs.exclusion-file }} ${{ inputs.kernel }}

--- a/build-notebooks/action.yml
+++ b/build-notebooks/action.yml
@@ -28,11 +28,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@v3.3.2
+  - uses: pyiron/actions/cached-miniforge@use_miniconda
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-notebooks-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@v3.3.2
+  - uses: pyiron/actions/pyiron-config@use_miniconda
   - name: Build notebooks
     shell: bash -l {0}
     run: $GITHUB_ACTION_PATH/../.support/build_notebooks.sh ${{ inputs.notebooks-dir }} ${{ inputs.exclusion-file }} ${{ inputs.kernel }}

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -62,7 +62,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: pyiron/actions/write-environment@use_miniconda
+  - uses: pyiron/actions/write-environment@actions-4.0.0
     with:
       env-files: ${{ inputs.env-files }}
   - name: Calculate cache label info

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -45,10 +45,6 @@ inputs:
     description: 'conda-incubator/setup-miniconda argument'
     default: 'true'
     required: false
-  miniforge-activate-environment:
-    description: 'DEPRECATED. Use env-path and include a path instead. If provided, will be used as the new env-path with ./cached-miniforge/ prepended as the path.'
-    default: ''
-    required: false
   pip-install-versioneer:
     description: 'Pip-install versioneer[toml]'
     default: 'true'
@@ -69,17 +65,6 @@ runs:
   - uses: pyiron/actions/write-environment@use_miniconda
     with:
       env-files: ${{ inputs.env-files }}
-  - name: Env name backwards compatibility patch
-    # Can be replaced with direct usage of `inputs.env-path` after a major version bump
-    id: env-path-backwards-compatibility
-    shell: bash -l {0}
-    run: |
-      if [ -z "${{ inputs.miniforge-activate-environment }}" ]; then
-          env_path=${{ inputs.env-path }}
-      else
-          env_path=./cached-miniforge/${{ inputs.miniforge-activate-environment }}
-      fi
-      echo env-path=${env_path} >> $GITHUB_OUTPUT
   - name: Calculate cache label info
     if: inputs.use-cache == 'true'
     id: cache-info

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -36,15 +36,14 @@ inputs:
   miniforge-channels:
     description: 'conda-incubator/setup-miniconda argument'
     default: conda-forge
-    # default: conda-forge,nodefaults  # TODO: Use nodefaults directly once setup-miniconda is fixed
     required: false
   miniforge-channel-priority:
     description: 'conda-incubator/setup-miniconda argument'
     default: strict
     required: false
-  miniforge-condarc-file:
-    description: 'conda-incubator/setup-miniconda argument, BUT we change the default to resolve https://github.com/conda-incubator/setup-miniconda/issues/207'
-    default: '.condarc'
+  miniforge-conda-remove-defaults:
+    description: 'conda-incubator/setup-miniconda argument'
+    default: 'true'
     required: false
   miniforge-activate-environment:
     description: 'DEPRECATED. Use env-path and include a path instead. If provided, will be used as the new env-path with cached-miniforge/ prepended as the path.'
@@ -102,29 +101,14 @@ runs:
       path: ${{ steps.env-path-backwards-compatibility.outputs.env-path }}
       key: ${{ steps.cache-info.outputs.CASH_KEY }}
       lookup-only: true
-  - name: Prepopulate condarc
-    # To resolve: https://github.com/conda-incubator/setup-miniconda/issues/207
-    # Because conda behaves like this: https://github.com/conda/conda/issues/12356
-    # And now using `default` can cost money: https://www.anaconda.com/blog/is-conda-free
-    # Only necessary until conda-incubator/setup-miniconda is fixed: https://github.com/conda-incubator/setup-miniconda/pull/364
-    shell: bash -l {0}
-    run: |
-      echo "channels:" > "${{ inputs.miniforge-condarc-file }}"
-      IFS=',' read -ra CHANNELS <<< "${{ inputs.miniforge-channels }}"
-      for channel in "${CHANNELS[@]}"; do
-          channel=$(echo "$channel" | xargs)
-          echo "- $channel" >> "${{ inputs.miniforge-condarc-file }}"
-      done
-      echo "Prepopulated condarc file ${{ inputs.miniforge-condarc-file }}:"
-      cat ${{ inputs.miniforge-condarc-file }}
   - name: Install using cached env
     if: inputs.use-cache == 'true' && steps.look-for-cache.outputs.cache-hit == 'true'
     uses: conda-incubator/setup-miniconda@v3
     with:
       miniforge-variant: ${{ inputs.miniforge-variant }}
       miniforge-version: ${{ inputs.miniforge-version }}
-      # channels: ${{ inputs.miniforge-channels }}
-      condarc-file: ${{ inputs.miniforge-condarc-file }}  # TODO: Use channels once setup-miniconda is fixed
+      channels: ${{ inputs.miniforge-channels }}
+      conda-remove-defaults: $${ miniforge-conda-remove-defaults }}
       channel-priority: ${{ inputs.miniforge-channel-priority }}
       activate-environment: ${{ steps.env-path-backwards-compatibility.outputs.env-path }}
   - name: Load cached environment
@@ -140,8 +124,8 @@ runs:
       python-version: ${{ inputs.python-version }}
       miniforge-variant: ${{ inputs.miniforge-variant }}
       miniforge-version: ${{ inputs.miniforge-version }}
-      # channels: ${{ inputs.miniforge-channels }}
-      condarc-file: ${{ inputs.miniforge-condarc-file }}  # TODO: Use channels once setup-miniconda is fixed
+      channels: ${{ inputs.miniforge-channels }}
+      conda-remove-defaults: $${ miniforge-conda-remove-defaults }}
       channel-priority: ${{ inputs.miniforge-channel-priority }}
       activate-environment: ${{ steps.env-path-backwards-compatibility.outputs.env-path }}
       environment-file: ${{ env.WRITE_ENVIRONMENT_OUTPUT_ENV_FILE }}

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -42,10 +42,6 @@ inputs:
     description: 'conda-incubator/setup-miniconda argument'
     default: strict
     required: false
-  miniforge-use-mamba:
-    description: 'conda-incubator/setup-miniconda argument'
-    default: 'true'
-    required: false
   miniforge-condarc-file:
     description: 'conda-incubator/setup-miniconda argument, BUT we change the default to resolve https://github.com/conda-incubator/setup-miniconda/issues/207'
     default: '.condarc'
@@ -131,7 +127,6 @@ runs:
       condarc-file: ${{ inputs.miniforge-condarc-file }}  # TODO: Use channels once setup-miniconda is fixed
       channel-priority: ${{ inputs.miniforge-channel-priority }}
       activate-environment: ${{ steps.env-path-backwards-compatibility.outputs.env-path }}
-      use-mamba: ${{ inputs.miniforge-use-mamba }}
   - name: Load cached environment
     if: inputs.use-cache == 'true' && steps.look-for-cache.outputs.cache-hit == 'true'
     uses: actions/cache/restore@v4
@@ -149,7 +144,6 @@ runs:
       condarc-file: ${{ inputs.miniforge-condarc-file }}  # TODO: Use channels once setup-miniconda is fixed
       channel-priority: ${{ inputs.miniforge-channel-priority }}
       activate-environment: ${{ steps.env-path-backwards-compatibility.outputs.env-path }}
-      use-mamba: ${{ inputs.miniforge-use-mamba }}
       environment-file: ${{ env.WRITE_ENVIRONMENT_OUTPUT_ENV_FILE }}
   - name: Cache new env
     if: inputs.use-cache == 'true' && steps.look-for-cache.outputs.cache-hit != 'true'

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
   env-path:
     description: 'A full path to the environment, used for miniconda activate-environment and cache path'
-    default: 'cached-miniforge/my-env'
+    default: './cached-miniforge/my-env'
     required: false
   local-code-directory:
     description: 'The location containing the code under development; targeted by pip install. If an empty string, local code will not be pip-installed at all!'
@@ -46,7 +46,7 @@ inputs:
     default: 'true'
     required: false
   miniforge-activate-environment:
-    description: 'DEPRECATED. Use env-path and include a path instead. If provided, will be used as the new env-path with cached-miniforge/ prepended as the path.'
+    description: 'DEPRECATED. Use env-path and include a path instead. If provided, will be used as the new env-path with ./cached-miniforge/ prepended as the path.'
     default: ''
     required: false
   pip-install-versioneer:
@@ -77,7 +77,7 @@ runs:
       if [ -z "${{ inputs.miniforge-activate-environment }}" ]; then
           env_path=${{ inputs.env-path }}
       else
-          env_path=cached-miniforge/${{ inputs.miniforge-activate-environment }}
+          env_path=./cached-miniforge/${{ inputs.miniforge-activate-environment }}
       fi
       echo env-path=${env_path} >> $GITHUB_OUTPUT
   - name: Calculate cache label info

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -67,7 +67,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: pyiron/actions/write-environment@v3.3.2
+  - uses: pyiron/actions/write-environment@use_miniconda
     with:
       env-files: ${{ inputs.env-files }}
   - name: Env name backwards compatibility patch

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -125,7 +125,7 @@ runs:
       miniforge-variant: ${{ inputs.miniforge-variant }}
       miniforge-version: ${{ inputs.miniforge-version }}
       channels: ${{ inputs.miniforge-channels }}
-      conda-remove-defaults: $${ miniforge-conda-remove-defaults }}
+      conda-remove-defaults: $${ inputs.miniforge-conda-remove-defaults }}
       channel-priority: ${{ inputs.miniforge-channel-priority }}
       activate-environment: ${{ steps.env-path-backwards-compatibility.outputs.env-path }}
       environment-file: ${{ env.WRITE_ENVIRONMENT_OUTPUT_ENV_FILE }}

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -72,7 +72,7 @@ runs:
     run: |
       pyversion_string=${{ inputs.python-version }}
       pyversion_string=${pyversion_string/\./-}
-      env_string=${{ steps.env-path-backwards-compatibility.outputs.env-path }}
+      env_string=${{ inputs.env-path }}
       env_string=${env_string//\//-}
       LABEL=${{ runner.os }}-${{ runner.arch }}-py-${pyversion_string}-${env_string}
       HASH=${{ hashFiles(env.WRITE_ENVIRONMENT_OUTPUT_ENV_FILE) }}
@@ -83,7 +83,7 @@ runs:
     uses: actions/cache/restore@v4
     id: look-for-cache
     with:
-      path: ${{ steps.env-path-backwards-compatibility.outputs.env-path }}
+      path: ${{ inputs.env-path }}
       key: ${{ steps.cache-info.outputs.CASH_KEY }}
       lookup-only: true
   - name: Install using cached env
@@ -95,12 +95,12 @@ runs:
       channels: ${{ inputs.miniforge-channels }}
       conda-remove-defaults: $${ miniforge-conda-remove-defaults }}
       channel-priority: ${{ inputs.miniforge-channel-priority }}
-      activate-environment: ${{ steps.env-path-backwards-compatibility.outputs.env-path }}
+      activate-environment: ${{ inputs.env-path }}
   - name: Load cached environment
     if: inputs.use-cache == 'true' && steps.look-for-cache.outputs.cache-hit == 'true'
     uses: actions/cache/restore@v4
     with:
-      path: ${{ steps.env-path-backwards-compatibility.outputs.env-path }}
+      path: ${{ inputs.env-path }}
       key: ${{ steps.cache-info.outputs.CASH_KEY }}
   - name: Build environment from file
     if: inputs.use-cache != 'true' || steps.look-for-cache.outputs.cache-hit != 'true'
@@ -112,14 +112,14 @@ runs:
       channels: ${{ inputs.miniforge-channels }}
       conda-remove-defaults: $${ inputs.miniforge-conda-remove-defaults }}
       channel-priority: ${{ inputs.miniforge-channel-priority }}
-      activate-environment: ${{ steps.env-path-backwards-compatibility.outputs.env-path }}
+      activate-environment: ${{ inputs.env-path }}
       environment-file: ${{ env.WRITE_ENVIRONMENT_OUTPUT_ENV_FILE }}
   - name: Cache new env
     if: inputs.use-cache == 'true' && steps.look-for-cache.outputs.cache-hit != 'true'
     uses: actions/cache/save@v4
     id: cache-env
     with:
-      path: ${{ steps.env-path-backwards-compatibility.outputs.env-path }}
+      path: ${{ inputs.env-path }}
       key: ${{ steps.cache-info.outputs.CASH_KEY }}
   - name: Display env info
     shell: bash -l {0}

--- a/pip-check/action.yml
+++ b/pip-check/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@v3.3.2
+  - uses: pyiron/actions/cached-miniforge@use_miniconda
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.env-files }}

--- a/pip-check/action.yml
+++ b/pip-check/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@use_miniconda
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.0
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.env-files }}

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -35,11 +35,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@use_miniconda
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.0
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-unittests-env-file }} ${{ inputs.coveralls-codacy-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@use_miniconda
+  - uses: pyiron/actions/pyiron-config@actions-4.0.0
   - name: Test
     shell: bash -l {0}
     run: |

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -35,11 +35,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@v3.3.2
+  - uses: pyiron/actions/cached-miniforge@use_miniconda
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-unittests-env-file }} ${{ inputs.coveralls-codacy-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@v3.3.2
+  - uses: pyiron/actions/pyiron-config@use_miniconda
   - name: Test
     shell: bash -l {0}
     run: |


### PR DESCRIPTION
As of five days ago, are getting [CI issues](https://github.com/pyiron/pyiron_workflow/issues/634). The mamba example on setup-miniconda stopped working too. I can't find or figure out a good direct attack, but mamba is deprecated anyhow so let's see whether it's possible to simply get around the problem by modernizing our setup-miniconda usage.

- Using mamba is deprecated, don't bother
- Localize env names containing paths with a `./` -- partially fixes https://github.com/pyiron/pyiron_workflow/issues/634
- Remove the backwards compatible env name input (since removing the mamba flags breaks the interface anyhow)
- Sneaky unrelated: patch the `sed` invocation for osx

It's been just about a year since v3 dropped, so instead of deprecating the `use_mamba` flag, let's just get rid of it, clean up the other deprecated flag, and make a major bump to v4 here.

Whatever made the prepended `./` in the env names suddenly necessary broke other things too, so I'm hoping it gets rolled back/fixed. However, I don't see that including it here hurts anything, so let's keep it around either way.