### PR TITLE
Use codecov

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
-      - uses: pyiron/actions/update-env-files@actions-4.0.0
+      - uses: pyiron/actions/update-env-files@use_codecov
       - name: UpdateDependabotPR commit
         run: |
           git config --local user.email "pyiron@mpie.de"

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -48,10 +48,10 @@ jobs:
 
   tests-and-coverage:
     if: contains(github.event.pull_request.labels.*.name, 'run_coverage')
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.0
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@use_codecov
     secrets: inherit
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'run_CodeQL')
-    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.0
+    uses: pyiron/actions/.github/workflows/codeql.yml@use_codecov
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -197,11 +197,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-docs-env@actions-4.0.0
+      - uses: pyiron/actions/write-docs-env@use_codecov
         with:
           env-files: ${{ inputs.docs-env-files }}
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-environment@actions-4.0.0
+      - uses: pyiron/actions/write-environment@use_codecov
         with:
           env-files: ${{ inputs.notebooks-env-files }}
           output-env-file: .binder/environment.yml
@@ -228,7 +228,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-docs@actions-4.0.0
+      - uses: pyiron/actions/build-docs@use_codecov
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.docs-env-files }}
@@ -239,7 +239,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-notebooks@actions-4.0.0
+      - uses: pyiron/actions/build-notebooks@use_codecov
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.notebooks-env-files }}
@@ -276,11 +276,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.0.0
+    - uses: pyiron/actions/add-to-python-path@use_codecov
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.0.0
+    - uses: pyiron/actions/unit-tests@use_codecov
       with:
         python-version: ${{ matrix.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -291,7 +291,7 @@ jobs:
   coveralls-and-codacy:
     needs: commit-updated-env
     if: ${{ inputs.do-coveralls || inputs.do-codacy }}
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.0
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@use_codecov
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
@@ -310,7 +310,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/unit-tests@actions-4.0.0
+    - uses: pyiron/actions/unit-tests@use_codecov
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -323,11 +323,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.0.0
+    - uses: pyiron/actions/add-to-python-path@use_codecov
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.0.0
+    - uses: pyiron/actions/unit-tests@use_codecov
       with:
         python-version: ${{ inputs.alternate-tests-python-version }}
         env-files: ${{ inputs.alternate-tests-env-files }}
@@ -341,7 +341,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/pip-check@actions-4.0.0
+      - uses: pyiron/actions/pip-check@use_codecov
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -31,14 +31,19 @@ on:
         description: 'Feature flag: controls if the unit-tests job runs.'
         default: true
         required: false
+      do-codecov:
+        type: boolean
+        description: 'Whether to use the codecov/codecov-action after generating coverage. If none of do-codecove, do-coveralls nor do-codacy are true, the coverage job is skipped.'
+        default: false
+        required: false
       do-coveralls:
         type: boolean
-        description: 'Whether to use the coveralls/github-action after generating coverage. If neither do-coveralls nor do-codacy are true, the coveralls-and-codacy job is skipped.'
+        description: 'Whether to use the coveralls/github-action after generating coverage. If none of do-codecove, do-coveralls nor do-codacy are true, the coverage job is skipped.'
         default: true
         required: false
       do-codacy:
         type: boolean
-        description: 'Whether to push the report to codacy after generating coverage. If neither do-coveralls nor do-codacy are true, the coveralls-and-codacy job is skipped.'
+        description: 'Whether to push the report to codacy after generating coverage. If none of do-codecove, do-coveralls nor do-codacy are true, the coverage job is skipped.'
         default: false
         required: false
       do-benchmark-tests:
@@ -91,9 +96,9 @@ on:
         description: 'timout-minutes to apply to running the unit tests'
         default: 10
         required: false
-      coveralls-and-codacy-timeout-minutes:
+      coverage-timeout-minutes:
         type: number
-        description: 'timout-minutes to apply to running the coveralls and codacy tests'
+        description: 'timout-minutes to apply to running the coverage tests'
         default: 15
         required: false
       benchmark-timeout-minutes:
@@ -151,9 +156,9 @@ on:
         description: 'The directory containing the unit tests run on the full platform and python matrix'
         default: tests/unit
         required: false
-      coveralls-and-codacy-test-dir:
+      coverage-test-dir:
         type: string
-        description: 'The directory containing the tests analyzed by coveralls'
+        description: 'The directory containing the tests analyzed for coverage'
         default: tests
         required: false
       benchmark-test-dir:
@@ -288,21 +293,21 @@ jobs:
         omit-patterns: ${{ inputs.omit-patterns }}
       timeout-minutes: ${{ inputs.unit-test-timeout-minutes }}
 
-  coveralls-and-codacy:
+  coverage:
     needs: commit-updated-env
-    if: ${{ inputs.do-coveralls || inputs.do-codacy }}
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@use_codecov
+    if: ${{ inputs.do-codecov || inputs.do-coveralls || inputs.do-codacy }}
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.0
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
       extra-python-paths: ${{ inputs.extra-python-paths }}
       runner: ${{ inputs.runner }}
       python-version: ${{ inputs.python-version }}
-      test-dir: ${{ inputs.coveralls-and-codacy-test-dir }}
+      test-dir: ${{ inputs.coverage-test-dir }}
       omit-patterns: ${{ inputs.omit-patterns }}
       do-coveralls: ${{ inputs.do-coveralls }}
       do-codacy: ${{ inputs.do-codacy }}
-      test-timeout-minutes: ${{ inputs.coveralls-and-codacy-timeout-minutes }}
+      test-timeout-minutes: ${{ inputs.coverage-timeout-minutes }}
 
   benchmark-tests:
     needs: commit-updated-env

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -83,11 +83,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/cached-miniforge@actions-4.0.0
+    - uses: pyiron/actions/cached-miniforge@use_codecov
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.0
+    - uses: pyiron/actions/update-pyproject-dependencies@use_codecov
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -48,6 +48,11 @@ on:
         description: 'timout-minutes to apply to running the tests'
         default: 15
         required: false
+      do-codecov:
+        type: boolean
+        description: 'Whether to use the codecov/codecov-action after generating coverage'
+        default: false
+        required: false
       do-coveralls:
         type: boolean
         description: 'Whether to use the coveralls/github-action after generating coverage'
@@ -82,6 +87,11 @@ jobs:
         run: |
           coverage combine
           coverage xml
+      - name: Upload coverage reports to Codecov
+        if: ${{ inputs.do-codecov }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Coveralls
         if: ${{ inputs.do-coveralls }}
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -64,11 +64,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@actions-4.0.0
+      - uses: pyiron/actions/add-to-python-path@use_codecov
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/unit-tests@actions-4.0.0
+      - uses: pyiron/actions/unit-tests@use_codecov
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.tests-env-files }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -79,6 +79,8 @@ jobs:
           env-files: ${{ inputs.tests-env-files }}
           test-dir: ${{ inputs.test-dir }}
           omit-patterns: ${{ inputs.omit-patterns }}
+          add-standard-codacy-env: ${{ inputs.do-codacy }}
+          add-standard-coveralls-env: ${{ inputs.do-coveralls }}
         timeout-minutes: ${{ inputs.test-timeout-minutes }}
       - name: Coverage
         shell: bash -l {0}

--- a/.support/environment-codacy.yml
+++ b/.support/environment-codacy.yml
@@ -1,5 +1,4 @@
 channels:
   - conda-forge
 dependencies:
-  - coveralls >= 3.3.1
   - codacy-coverage

--- a/.support/environment-coveralls.yml
+++ b/.support/environment-coveralls.yml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - coveralls >= 3.3.1

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.0
+    uses: pyiron/actions/.github/workflows/push-pull.yml@use_codecov
     secrets: inherit
 ```
 

--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -21,11 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.0
+  - uses: pyiron/actions/cached-miniforge@use_codecov
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-docs-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.0
+  - uses: pyiron/actions/pyiron-config@use_codecov
   - name: Build sphinx documentation
     shell: bash -l {0}
     run: |

--- a/build-notebooks/action.yml
+++ b/build-notebooks/action.yml
@@ -28,11 +28,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.0
+  - uses: pyiron/actions/cached-miniforge@use_codecov
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-notebooks-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.0
+  - uses: pyiron/actions/pyiron-config@use_codecov
   - name: Build notebooks
     shell: bash -l {0}
     run: $GITHUB_ACTION_PATH/../.support/build_notebooks.sh ${{ inputs.notebooks-dir }} ${{ inputs.exclusion-file }} ${{ inputs.kernel }}

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -62,7 +62,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: pyiron/actions/write-environment@actions-4.0.0
+  - uses: pyiron/actions/write-environment@use_codecov
     with:
       env-files: ${{ inputs.env-files }}
   - name: Calculate cache label info

--- a/pip-check/action.yml
+++ b/pip-check/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.0
+  - uses: pyiron/actions/cached-miniforge@use_codecov
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.env-files }}

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -15,10 +15,15 @@ inputs:
     description: 'Env files this action thinks are useful (adds jupyter and papermill packages)'
     default: $GITHUB_ACTION_PATH/../.support/environment-unittests.yml
     required: false
-  coveralls-codacy-env-file:
+  codacy-env-file:
     type: string
     description: 'An extra env file since we usually combine this action with coverage+unittest, and called workflows cannot access their own repo'
-    default: $GITHUB_ACTION_PATH/../.support/environment-coveralls-codacy.yml
+    default: $GITHUB_ACTION_PATH/../.support/environment-codacy.yml
+    required: false
+  coveralls-env-file:
+    type: string
+    description: 'An extra env file since we usually combine this action with coverage+unittest, and called workflows cannot access their own repo'
+    default: $GITHUB_ACTION_PATH/../.support/environment-coveralls.yml
     required: false
   test-dir:
     type: string
@@ -38,7 +43,7 @@ runs:
   - uses: pyiron/actions/cached-miniforge@use_codecov
     with:
       python-version: ${{ inputs.python-version }}
-      env-files: ${{ inputs.standard-unittests-env-file }} ${{ inputs.coveralls-codacy-env-file }} ${{ inputs.env-files }}
+      env-files: ${{ inputs.standard-unittests-env-file }} ${{ inputs.codacy-env-file }} ${{ inputs.coveralls-env-file }} ${{ inputs.env-files }}
   - uses: pyiron/actions/pyiron-config@use_codecov
   - name: Test
     shell: bash -l {0}

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -35,11 +35,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.0
+  - uses: pyiron/actions/cached-miniforge@use_codecov
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-unittests-env-file }} ${{ inputs.coveralls-codacy-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.0
+  - uses: pyiron/actions/pyiron-config@use_codecov
   - name: Test
     shell: bash -l {0}
     run: |

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -15,15 +15,15 @@ inputs:
     description: 'Env files this action thinks are useful (adds jupyter and papermill packages)'
     default: $GITHUB_ACTION_PATH/../.support/environment-unittests.yml
     required: false
-  codacy-env-file:
-    type: string
-    description: 'An extra env file since we usually combine this action with coverage+unittest, and called workflows cannot access their own repo'
-    default: $GITHUB_ACTION_PATH/../.support/environment-codacy.yml
+  add-standard-codacy-env:
+    type: boolean
+    description: 'Whether to include the standard Codacy environment file'
+    default: false
     required: false
-  coveralls-env-file:
-    type: string
-    description: 'An extra env file since we usually combine this action with coverage+unittest, and called workflows cannot access their own repo'
-    default: $GITHUB_ACTION_PATH/../.support/environment-coveralls.yml
+  add-standard-coveralls-env:
+    type: boolean
+    description: 'Whether to include the standard Coveralls environment file'
+    default: false
     required: false
   test-dir:
     type: string
@@ -40,10 +40,27 @@ inputs:
 runs:
   using: 'composite'
   steps:
+  - name: Prepare environment files
+    id: prepare-env-files
+    shell: bash -l {0}
+    run: |
+      ENV_FILES="${{ inputs.standard-unittests-env-file }}"
+
+      if [[ "${{ inputs.add-standard-codacy-env }}" == "true" ]]; then
+        ENV_FILES="$ENV_FILES $GITHUB_ACTION_PATH/../.support/environment-codacy.yml"
+      fi
+
+      if [[ "${{ inputs.add-standard-coveralls-env }}" == "true" ]]; then
+        ENV_FILES="$ENV_FILES $GITHUB_ACTION_PATH/../.support/environment-coveralls.yml"
+      fi
+
+      ENV_FILES="$ENV_FILES ${{ inputs.env-files }}"
+      echo "env_files=$ENV_FILES" >> $GITHUB_OUTPUT
+
   - uses: pyiron/actions/cached-miniforge@use_codecov
     with:
       python-version: ${{ inputs.python-version }}
-      env-files: ${{ inputs.standard-unittests-env-file }} ${{ inputs.codacy-env-file }} ${{ inputs.coveralls-env-file }} ${{ inputs.env-files }}
+      env-files: ${{ steps.prepare-env-files.outputs.env_files }}
   - uses: pyiron/actions/pyiron-config@use_codecov
   - name: Test
     shell: bash -l {0}

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -15,15 +15,25 @@ inputs:
     description: 'Env files this action thinks are useful (adds jupyter and papermill packages)'
     default: $GITHUB_ACTION_PATH/../.support/environment-unittests.yml
     required: false
+  standard-codacy-env-file:
+    type: string
+    description: 'Path to the Codacy environment file. DEPRECATED: Include custom envs in env-files input, or enable the default with add-standard-codacy-env'
+    default: ''
+    required: false
+  standard-coveralls-env-file:
+    type: string
+    description: 'Path to the Coveralls environment file. DEPRECATED: Include custom envs in env-files input, or enable the default with add-standard-coveralls-env'
+    default: ''
+    required: false
   add-standard-codacy-env:
     type: boolean
     description: 'Whether to include the standard Codacy environment file'
-    default: false
+    default: true
     required: false
   add-standard-coveralls-env:
     type: boolean
     description: 'Whether to include the standard Coveralls environment file'
-    default: false
+    default: true
     required: false
   test-dir:
     type: string
@@ -46,11 +56,17 @@ runs:
     run: |
       ENV_FILES="${{ inputs.standard-unittests-env-file }}"
 
-      if [[ "${{ inputs.add-standard-codacy-env }}" == "true" ]]; then
+      # For Codacy: use the specified file if not empty, otherwise use the standard file if the flag is true
+      if [[ -n "${{ inputs.standard-codacy-env-file }}" ]]; then
+        ENV_FILES="$ENV_FILES ${{ inputs.standard-codacy-env-file }}"
+      elif [[ "${{ inputs.add-standard-codacy-env }}" == "true" ]]; then
         ENV_FILES="$ENV_FILES $GITHUB_ACTION_PATH/../.support/environment-codacy.yml"
       fi
 
-      if [[ "${{ inputs.add-standard-coveralls-env }}" == "true" ]]; then
+      # For Coveralls: use the specified file if not empty, otherwise use the standard file if the flag is true
+      if [[ -n "${{ inputs.standard-coveralls-env-file }}" ]]; then
+        ENV_FILES="$ENV_FILES ${{ inputs.standard-coveralls-env-file }}"
+      elif [[ "${{ inputs.add-standard-coveralls-env }}" == "true" ]]; then
         ENV_FILES="$ENV_FILES $GITHUB_ACTION_PATH/../.support/environment-coveralls.yml"
       fi
 


### PR DESCRIPTION
Adds new flags in the unit-tests action (without breaking compatibility) and exploits them in the reusable workflows (tests-and-coverage) to only add the coveralls and codacy packages to the env if we're actually doing those. Then stacks on top codecov in the tests-and-coverage workflow.

Right now the default behaviour is still all the codecov stuff, but let's make that the default and turn off coveralls and codacy if it works ok.