### PR TITLE
[patch] Limit coverage env

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
-      - uses: pyiron/actions/update-env-files@actions-4.0.1
+      - uses: pyiron/actions/update-env-files@limit_coverage_env
       - name: UpdateDependabotPR commit
         run: |
           git config --local user.email "pyiron@mpie.de"

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
-      - uses: pyiron/actions/update-env-files@limit_coverage_env
+      - uses: pyiron/actions/update-env-files@actions-4.0.2
       - name: UpdateDependabotPR commit
         run: |
           git config --local user.email "pyiron@mpie.de"

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -48,10 +48,10 @@ jobs:
 
   tests-and-coverage:
     if: contains(github.event.pull_request.labels.*.name, 'run_coverage')
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@limit_coverage_env
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.2
     secrets: inherit
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'run_CodeQL')
-    uses: pyiron/actions/.github/workflows/codeql.yml@limit_coverage_env
+    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.2
     secrets: inherit

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -48,10 +48,10 @@ jobs:
 
   tests-and-coverage:
     if: contains(github.event.pull_request.labels.*.name, 'run_coverage')
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.1
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@limit_coverage_env
     secrets: inherit
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'run_CodeQL')
-    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.1
+    uses: pyiron/actions/.github/workflows/codeql.yml@limit_coverage_env
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -202,11 +202,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-docs-env@actions-4.0.1
+      - uses: pyiron/actions/write-docs-env@limit_coverage_env
         with:
           env-files: ${{ inputs.docs-env-files }}
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-environment@actions-4.0.1
+      - uses: pyiron/actions/write-environment@limit_coverage_env
         with:
           env-files: ${{ inputs.notebooks-env-files }}
           output-env-file: .binder/environment.yml
@@ -233,7 +233,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-docs@actions-4.0.1
+      - uses: pyiron/actions/build-docs@limit_coverage_env
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.docs-env-files }}
@@ -244,7 +244,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-notebooks@actions-4.0.1
+      - uses: pyiron/actions/build-notebooks@limit_coverage_env
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.notebooks-env-files }}
@@ -281,11 +281,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.0.1
+    - uses: pyiron/actions/add-to-python-path@limit_coverage_env
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.0.1
+    - uses: pyiron/actions/unit-tests@limit_coverage_env
       with:
         python-version: ${{ matrix.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -296,7 +296,7 @@ jobs:
   coverage:
     needs: commit-updated-env
     if: ${{ inputs.do-codecov || inputs.do-coveralls || inputs.do-codacy }}
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.1
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@limit_coverage_env
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
@@ -316,7 +316,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/unit-tests@actions-4.0.1
+    - uses: pyiron/actions/unit-tests@limit_coverage_env
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -329,11 +329,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.0.1
+    - uses: pyiron/actions/add-to-python-path@limit_coverage_env
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.0.1
+    - uses: pyiron/actions/unit-tests@limit_coverage_env
       with:
         python-version: ${{ inputs.alternate-tests-python-version }}
         env-files: ${{ inputs.alternate-tests-env-files }}
@@ -347,7 +347,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/pip-check@actions-4.0.1
+      - uses: pyiron/actions/pip-check@limit_coverage_env
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -202,11 +202,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-docs-env@limit_coverage_env
+      - uses: pyiron/actions/write-docs-env@actions-4.0.2
         with:
           env-files: ${{ inputs.docs-env-files }}
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-environment@limit_coverage_env
+      - uses: pyiron/actions/write-environment@actions-4.0.2
         with:
           env-files: ${{ inputs.notebooks-env-files }}
           output-env-file: .binder/environment.yml
@@ -233,7 +233,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-docs@limit_coverage_env
+      - uses: pyiron/actions/build-docs@actions-4.0.2
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.docs-env-files }}
@@ -244,7 +244,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-notebooks@limit_coverage_env
+      - uses: pyiron/actions/build-notebooks@actions-4.0.2
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.notebooks-env-files }}
@@ -281,11 +281,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@limit_coverage_env
+    - uses: pyiron/actions/add-to-python-path@actions-4.0.2
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@limit_coverage_env
+    - uses: pyiron/actions/unit-tests@actions-4.0.2
       with:
         python-version: ${{ matrix.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -298,7 +298,7 @@ jobs:
   coverage:
     needs: commit-updated-env
     if: ${{ inputs.do-codecov || inputs.do-coveralls || inputs.do-codacy }}
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@limit_coverage_env
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.2
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
@@ -318,7 +318,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/unit-tests@limit_coverage_env
+    - uses: pyiron/actions/unit-tests@actions-4.0.2
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -333,11 +333,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@limit_coverage_env
+    - uses: pyiron/actions/add-to-python-path@actions-4.0.2
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@limit_coverage_env
+    - uses: pyiron/actions/unit-tests@actions-4.0.2
       with:
         python-version: ${{ inputs.alternate-tests-python-version }}
         env-files: ${{ inputs.alternate-tests-env-files }}
@@ -353,7 +353,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/pip-check@limit_coverage_env
+      - uses: pyiron/actions/pip-check@actions-4.0.2
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -291,6 +291,8 @@ jobs:
         env-files: ${{ inputs.tests-env-files }}
         test-dir: ${{ inputs.unit-test-dir }}
         omit-patterns: ${{ inputs.omit-patterns }}
+        add-standard-codacy-env: false
+        add-standard-coveralls-env: false
       timeout-minutes: ${{ inputs.unit-test-timeout-minutes }}
 
   coverage:
@@ -322,6 +324,8 @@ jobs:
         env-files: ${{ inputs.tests-env-files }}
         test-dir: ${{ inputs.benchmark-test-dir }}
         omit-patterns: ${{ inputs.omit-patterns }}
+        add-standard-codacy-env: false
+        add-standard-coveralls-env: false
       timeout-minutes: ${{ inputs.benchmark-timeout-minutes }}
 
   test-alternate-env:
@@ -339,6 +343,8 @@ jobs:
         env-files: ${{ inputs.alternate-tests-env-files }}
         test-dir: ${{ inputs.alternate-tests-dir }}
         omit-patterns: ${{ inputs.omit-patterns }}
+        add-standard-codacy-env: false
+        add-standard-coveralls-env: false
       timeout-minutes:  ${{ inputs.alternate-tests-timeout-minutes }}
 
   pip-check:

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -83,11 +83,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/cached-miniforge@limit_coverage_env
+    - uses: pyiron/actions/cached-miniforge@actions-4.0.2
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@limit_coverage_env
+    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.2
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -83,11 +83,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/cached-miniforge@actions-4.0.1
+    - uses: pyiron/actions/cached-miniforge@limit_coverage_env
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.1
+    - uses: pyiron/actions/update-pyproject-dependencies@limit_coverage_env
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -69,11 +69,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@limit_coverage_env
+      - uses: pyiron/actions/add-to-python-path@actions-4.0.2
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/unit-tests@limit_coverage_env
+      - uses: pyiron/actions/unit-tests@actions-4.0.2
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.tests-env-files }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -69,11 +69,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@actions-4.0.1
+      - uses: pyiron/actions/add-to-python-path@limit_coverage_env
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/unit-tests@actions-4.0.1
+      - uses: pyiron/actions/unit-tests@limit_coverage_env
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.tests-env-files }}

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.1
+    uses: pyiron/actions/.github/workflows/push-pull.yml@limit_coverage_env
     secrets: inherit
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@limit_coverage_env
+    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.2
     secrets: inherit
 ```
 

--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -21,11 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@limit_coverage_env
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.2
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-docs-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@limit_coverage_env
+  - uses: pyiron/actions/pyiron-config@actions-4.0.2
   - name: Build sphinx documentation
     shell: bash -l {0}
     run: |

--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -21,11 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.1
+  - uses: pyiron/actions/cached-miniforge@limit_coverage_env
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-docs-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.1
+  - uses: pyiron/actions/pyiron-config@limit_coverage_env
   - name: Build sphinx documentation
     shell: bash -l {0}
     run: |

--- a/build-notebooks/action.yml
+++ b/build-notebooks/action.yml
@@ -28,11 +28,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@limit_coverage_env
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.2
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-notebooks-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@limit_coverage_env
+  - uses: pyiron/actions/pyiron-config@actions-4.0.2
   - name: Build notebooks
     shell: bash -l {0}
     run: $GITHUB_ACTION_PATH/../.support/build_notebooks.sh ${{ inputs.notebooks-dir }} ${{ inputs.exclusion-file }} ${{ inputs.kernel }}

--- a/build-notebooks/action.yml
+++ b/build-notebooks/action.yml
@@ -28,11 +28,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.1
+  - uses: pyiron/actions/cached-miniforge@limit_coverage_env
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-notebooks-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.1
+  - uses: pyiron/actions/pyiron-config@limit_coverage_env
   - name: Build notebooks
     shell: bash -l {0}
     run: $GITHUB_ACTION_PATH/../.support/build_notebooks.sh ${{ inputs.notebooks-dir }} ${{ inputs.exclusion-file }} ${{ inputs.kernel }}

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -62,7 +62,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: pyiron/actions/write-environment@limit_coverage_env
+  - uses: pyiron/actions/write-environment@actions-4.0.2
     with:
       env-files: ${{ inputs.env-files }}
   - name: Calculate cache label info

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -62,7 +62,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: pyiron/actions/write-environment@actions-4.0.1
+  - uses: pyiron/actions/write-environment@limit_coverage_env
     with:
       env-files: ${{ inputs.env-files }}
   - name: Calculate cache label info

--- a/pip-check/action.yml
+++ b/pip-check/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.1
+  - uses: pyiron/actions/cached-miniforge@limit_coverage_env
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.env-files }}

--- a/pip-check/action.yml
+++ b/pip-check/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@limit_coverage_env
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.2
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.env-files }}

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -72,11 +72,11 @@ runs:
       echo "ENV_FILES = ${ENV_FILES}"
       echo "env_files=$ENV_FILES" >> $GITHUB_OUTPUT
 
-  - uses: pyiron/actions/cached-miniforge@limit_coverage_env
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.2
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ steps.prepare-env-files.outputs.env_files }}
-  - uses: pyiron/actions/pyiron-config@limit_coverage_env
+  - uses: pyiron/actions/pyiron-config@actions-4.0.2
   - name: Test
     shell: bash -l {0}
     run: |

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -72,11 +72,11 @@ runs:
       echo "ENV_FILES = ${ENV_FILES}"
       echo "env_files=$ENV_FILES" >> $GITHUB_OUTPUT
 
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.1
+  - uses: pyiron/actions/cached-miniforge@limit_coverage_env
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ steps.prepare-env-files.outputs.env_files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.1
+  - uses: pyiron/actions/pyiron-config@limit_coverage_env
   - name: Test
     shell: bash -l {0}
     run: |


### PR DESCRIPTION
To times when we're actually trying to get the coverage.

#146 left the codacy and coveralls env as part of the `unit-test` action environment, which is correct in terms of backwards compatibility, but in the actual reusable workflows we can and want to turn it off whenever we're not actually trying to run coverage.