### PR TITLE
Allow multiple test directories

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
-      - uses: pyiron/actions/update-env-files@actions-4.0.6
+      - uses: pyiron/actions/update-env-files@actions-4.0.7
       - name: UpdateDependabotPR commit
         run: |
           git config --local user.email "pyiron@mpie.de"

--- a/.github/workflows/hatch-release.yml
+++ b/.github/workflows/hatch-release.yml
@@ -86,11 +86,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/cached-miniforge@actions-4.0.6
+    - uses: pyiron/actions/cached-miniforge@actions-4.0.7
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.6
+    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.7
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -48,10 +48,10 @@ jobs:
 
   tests-and-coverage:
     if: contains(github.event.pull_request.labels.*.name, 'run_coverage')
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.7
     secrets: inherit
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'run_CodeQL')
-    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.7
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -207,11 +207,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-docs-env@actions-4.0.6
+      - uses: pyiron/actions/write-docs-env@actions-4.0.7
         with:
           env-files: ${{ inputs.docs-env-files }}
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-environment@actions-4.0.6
+      - uses: pyiron/actions/write-environment@actions-4.0.7
         with:
           env-files: ${{ inputs.notebooks-env-files }}
           output-env-file: .binder/environment.yml
@@ -238,11 +238,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@actions-4.0.6
+      - uses: pyiron/actions/add-to-python-path@actions-4.0.7
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/build-docs@actions-4.0.6
+      - uses: pyiron/actions/build-docs@actions-4.0.7
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.docs-env-files }}
@@ -253,11 +253,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@actions-4.0.6
+      - uses: pyiron/actions/add-to-python-path@actions-4.0.7
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/build-notebooks@actions-4.0.6
+      - uses: pyiron/actions/build-notebooks@actions-4.0.7
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.notebooks-env-files }}
@@ -294,11 +294,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.0.6
+    - uses: pyiron/actions/add-to-python-path@actions-4.0.7
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.0.6
+    - uses: pyiron/actions/unit-tests@actions-4.0.7
       with:
         python-version: ${{ matrix.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -311,7 +311,7 @@ jobs:
   coverage:
     needs: commit-updated-env
     if: ${{ inputs.do-codecov || inputs.do-coveralls || inputs.do-codacy }}
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.7
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
@@ -331,11 +331,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.0.6
+    - uses: pyiron/actions/add-to-python-path@actions-4.0.7
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.0.6
+    - uses: pyiron/actions/unit-tests@actions-4.0.7
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -350,11 +350,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.0.6
+    - uses: pyiron/actions/add-to-python-path@actions-4.0.7
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.0.6
+    - uses: pyiron/actions/unit-tests@actions-4.0.7
       with:
         python-version: ${{ inputs.alternate-tests-python-version }}
         env-files: ${{ inputs.alternate-tests-env-files }}
@@ -370,7 +370,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/pip-check@actions-4.0.6
+      - uses: pyiron/actions/pip-check@actions-4.0.7
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -158,17 +158,17 @@ on:
         required: false
       unit-test-dir:
         type: string
-        description: 'The directory containing the unit tests run on the full platform and python matrix'
+        description: 'The directory (or space-separated directories) containing the unit tests run on the full platform and python matrix'
         default: tests/unit
         required: false
       coverage-test-dir:
         type: string
-        description: 'The directory containing the tests analyzed for coverage'
+        description: 'The directory (or space-separated directories) containing the tests analyzed for coverage'
         default: tests
         required: false
       benchmark-test-dir:
         type: string
-        description: 'The directory containing the benchmark tests'
+        description: 'The directory (or space-separated directories) containing the benchmark tests'
         default: tests/benchmark
         required: false
       omit-patterns:

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -83,11 +83,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/cached-miniforge@actions-4.0.6
+    - uses: pyiron/actions/cached-miniforge@actions-4.0.7
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.6
+    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.7
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -15,7 +15,7 @@ on:
     inputs:
       test-dir:
         type: string
-        description: 'The directory containing the tests'
+        description: 'The directory (or space-separated directories) containing the tests'
         default: tests
         required: false
       omit-patterns:

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -69,11 +69,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@actions-4.0.6
+      - uses: pyiron/actions/add-to-python-path@actions-4.0.7
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/unit-tests@actions-4.0.6
+      - uses: pyiron/actions/unit-tests@actions-4.0.7
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.tests-env-files }}

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.7
     secrets: inherit
 ```
 

--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -21,11 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.6
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.7
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-docs-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.6
+  - uses: pyiron/actions/pyiron-config@actions-4.0.7
   - name: Build sphinx documentation
     shell: bash -l {0}
     run: |

--- a/build-notebooks/action.yml
+++ b/build-notebooks/action.yml
@@ -28,11 +28,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.6
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.7
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-notebooks-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.6
+  - uses: pyiron/actions/pyiron-config@actions-4.0.7
   - name: Build notebooks
     shell: bash -l {0}
     run: $GITHUB_ACTION_PATH/../.support/build_notebooks.sh ${{ inputs.notebooks-dir }} ${{ inputs.exclusion-file }} ${{ inputs.kernel }}

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -62,7 +62,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: pyiron/actions/write-environment@actions-4.0.6
+  - uses: pyiron/actions/write-environment@actions-4.0.7
     with:
       env-files: ${{ inputs.env-files }}
   - name: Calculate cache label info

--- a/pip-check/action.yml
+++ b/pip-check/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.6
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.7
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.env-files }}

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -72,11 +72,11 @@ runs:
       echo "ENV_FILES = ${ENV_FILES}"
       echo "env_files=$ENV_FILES" >> $GITHUB_OUTPUT
 
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.6
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.7
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ steps.prepare-env-files.outputs.env_files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.6
+  - uses: pyiron/actions/pyiron-config@actions-4.0.7
   - name: Test
     shell: bash -l {0}
     run: |

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
   test-dir:
     type: string
-    description: 'The directory containing the tests'
+    description: 'The directory (or space-separated directories) containing the tests'
     default: tests
     required: false
   omit-patterns:
@@ -80,4 +80,6 @@ runs:
   - name: Test
     shell: bash -l {0}
     run: |
-      coverage run --omit=${{ inputs.omit-patterns }} -m unittest discover ${{ inputs.test-dir }}
+      for dir in ${{ inputs.test-dir }}; do
+        coverage run --append --omit="${{ inputs.omit-patterns }}" -m unittest discover "$dir"
+      done

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -80,6 +80,7 @@ runs:
   - name: Test
     shell: bash -l {0}
     run: |
-      for dir in ${{ inputs.test-dir }}; do
+      IFS=' ' read -r -a test_dirs <<< "${{ inputs.test-dir }}"
+      for dir in "${test_dirs[@]}"; do
         coverage run --append --omit="${{ inputs.omit-patterns }}" -m unittest discover "$dir"
       done


### PR DESCRIPTION
In the unit-test action, and propagate the docstring change up through the tools that depend on this. This gives finer-grained control for which tests to run where (in particular, to exclude the benchmark tests from the coverage run, if you want)