### PR TITLE
Actions 4.0.13

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
-      - uses: pyiron/actions/update-env-files@actions-4.0.12
+      - uses: pyiron/actions/update-env-files@actions-4.0.13
       - name: UpdateDependabotPR commit
         run: |
           git config --local user.email "pyiron@mpie.de"

--- a/.github/workflows/hatch-release.yml
+++ b/.github/workflows/hatch-release.yml
@@ -106,11 +106,11 @@ jobs:
     - name: Install npm dependencies
       if: inputs.use-node
       run: npm install
-    - uses: pyiron/actions/cached-miniforge@actions-4.0.12
+    - uses: pyiron/actions/cached-miniforge@actions-4.0.13
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.12
+    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.13
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -48,10 +48,10 @@ jobs:
 
   tests-and-coverage:
     if: contains(github.event.pull_request.labels.*.name, 'run_coverage')
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.12
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.13
     secrets: inherit
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'run_CodeQL')
-    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.12
+    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.13
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -436,7 +436,7 @@ jobs:
           env-files: ${{ inputs.mypy-env-files }}
       - name: Install mypy
         shell: bash -l {0}
-        run: pip install mypy
+        run: python -m pip install mypy
       - name: Test
         shell: bash -l {0}
         run: mypy . ${{ inputs.mypy-env-files != '' && '--exclude cached-miniforge' || '' }}

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -212,11 +212,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-docs-env@actions-4.0.12
+      - uses: pyiron/actions/write-docs-env@actions-4.0.13
         with:
           env-files: ${{ inputs.docs-env-files }}
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-environment@actions-4.0.12
+      - uses: pyiron/actions/write-environment@actions-4.0.13
         with:
           env-files: ${{ inputs.notebooks-env-files }}
           output-env-file: .binder/environment.yml
@@ -243,11 +243,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@actions-4.0.12
+      - uses: pyiron/actions/add-to-python-path@actions-4.0.13
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/build-docs@actions-4.0.12
+      - uses: pyiron/actions/build-docs@actions-4.0.13
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.docs-env-files }}
@@ -258,11 +258,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@actions-4.0.12
+      - uses: pyiron/actions/add-to-python-path@actions-4.0.13
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/build-notebooks@actions-4.0.12
+      - uses: pyiron/actions/build-notebooks@actions-4.0.13
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.notebooks-env-files }}
@@ -299,11 +299,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.0.12
+    - uses: pyiron/actions/add-to-python-path@actions-4.0.13
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.0.12
+    - uses: pyiron/actions/unit-tests@actions-4.0.13
       with:
         python-version: ${{ matrix.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -316,7 +316,7 @@ jobs:
   coverage:
     needs: commit-updated-env
     if: ${{ inputs.do-codecov || inputs.do-coveralls || inputs.do-codacy }}
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.12
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.13
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
@@ -336,11 +336,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.0.12
+    - uses: pyiron/actions/add-to-python-path@actions-4.0.13
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.0.12
+    - uses: pyiron/actions/unit-tests@actions-4.0.13
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -355,11 +355,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.0.12
+    - uses: pyiron/actions/add-to-python-path@actions-4.0.13
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.0.12
+    - uses: pyiron/actions/unit-tests@actions-4.0.13
       with:
         python-version: ${{ inputs.alternate-tests-python-version }}
         env-files: ${{ inputs.alternate-tests-env-files }}
@@ -375,7 +375,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/pip-check@actions-4.0.12
+      - uses: pyiron/actions/pip-check@actions-4.0.13
         with:
           python-version: ${{ inputs.python-version }}
 
@@ -430,7 +430,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
           architecture: x64
       - if: ${{ inputs.mypy-env-files != '' }}
-        uses: pyiron/actions/cached-miniforge@actions-4.0.12
+        uses: pyiron/actions/cached-miniforge@actions-4.0.13
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.mypy-env-files }}

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -83,11 +83,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/cached-miniforge@actions-4.0.12
+    - uses: pyiron/actions/cached-miniforge@actions-4.0.13
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.12
+    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.0.13
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Build
       shell: bash -l {0}
       run: |
-        pip install versioneer[toml]==0.29
+        python -m pip install versioneer[toml]==0.29
         python setup.py sdist bdist_wheel
     - name: Publish distribution 📦 to PyPI
       if: inputs.publish-to-pypi

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -69,11 +69,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@actions-4.0.12
+      - uses: pyiron/actions/add-to-python-path@actions-4.0.13
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/unit-tests@actions-4.0.12
+      - uses: pyiron/actions/unit-tests@actions-4.0.13
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.tests-env-files }}

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.12
+    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.13
     secrets: inherit
 ```
 

--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -21,11 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.12
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.13
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-docs-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.12
+  - uses: pyiron/actions/pyiron-config@actions-4.0.13
   - name: Build sphinx documentation
     shell: bash -l {0}
     run: |

--- a/build-notebooks/action.yml
+++ b/build-notebooks/action.yml
@@ -28,11 +28,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.12
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.13
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-notebooks-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.12
+  - uses: pyiron/actions/pyiron-config@actions-4.0.13
   - name: Build notebooks
     shell: bash -l {0}
     run: $GITHUB_ACTION_PATH/../.support/build_notebooks.sh ${{ inputs.notebooks-dir }} ${{ inputs.exclusion-file }} ${{ inputs.kernel }}

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -62,7 +62,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: pyiron/actions/write-environment@actions-4.0.12
+  - uses: pyiron/actions/write-environment@actions-4.0.13
     with:
       env-files: ${{ inputs.env-files }}
   - name: Calculate cache label info

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -131,12 +131,12 @@ runs:
     if: inputs.local-code-directory != '' && inputs.pip-install-versioneer == 'true'
     shell: bash -l {0}
     run: |
-      pip install versioneer[toml]==${{ inputs.versioneer-version }}
+      python -m pip install versioneer[toml]==${{ inputs.versioneer-version }}
   - name: Install local code without build isolation
     if: inputs.local-code-directory != '' && inputs.no-build-isolation == 'true'
     shell: bash -l {0}
-    run: pip install --no-deps ${{ inputs.local-code-directory }} --no-build-isolation
+    run: python -m pip install --no-deps ${{ inputs.local-code-directory }} --no-build-isolation
   - name: Install local code with build isolation
     if: inputs.local-code-directory != '' && inputs.no-build-isolation != 'true'
     shell: bash -l {0}
-    run: pip install --no-deps ${{ inputs.local-code-directory }}
+    run: python -m pip install --no-deps ${{ inputs.local-code-directory }}

--- a/pip-check/action.yml
+++ b/pip-check/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.12
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.13
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.env-files }}

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -72,11 +72,11 @@ runs:
       echo "ENV_FILES = ${ENV_FILES}"
       echo "env_files=$ENV_FILES" >> $GITHUB_OUTPUT
 
-  - uses: pyiron/actions/cached-miniforge@actions-4.0.12
+  - uses: pyiron/actions/cached-miniforge@actions-4.0.13
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ steps.prepare-env-files.outputs.env_files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.0.12
+  - uses: pyiron/actions/pyiron-config@actions-4.0.13
   - name: Test
     shell: bash -l {0}
     run: |

--- a/update-env-files/action.yml
+++ b/update-env-files/action.yml
@@ -13,7 +13,7 @@ runs:
   - name: Ensure yaml module is present
     # Ubuntu works fine, but both windows and macos wind up complaining that there is no module "yaml"
     shell: bash -l {0}
-    run: pip install pyyaml
+    run: python -m pip install pyyaml
   - name: Update environment files
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}

--- a/update-pyproject-dependencies/action.yml
+++ b/update-pyproject-dependencies/action.yml
@@ -55,8 +55,8 @@ runs:
   - name: Install dependencies
     shell: bash -l {0}
     run: |
-      pip install pyyaml==${{ inputs.pyyaml-version }}
-      pip install toml==${{ inputs.toml-version }}
+      python -m pip install pyyaml==${{ inputs.pyyaml-version }}
+      python -m pip install toml==${{ inputs.toml-version }}
   - name: Write updated toml file
     shell: bash -l {0}
     run: |

--- a/write-environment/action.yml
+++ b/write-environment/action.yml
@@ -16,7 +16,7 @@ runs:
   - name: Ensure yaml module is present
     # Ubuntu works fine, but both windows and macos wind up complaining that there is no module "yaml"
     shell: bash -l {0}
-    run: pip install pyyaml
+    run: python -m pip install pyyaml
   - name: Write environment
     shell: bash -l {0}
     run: |


### PR DESCRIPTION
Moving the `flowrep/flowrep` code down into `flowrep/src/flowrep` [here](https://github.com/pyiron/flowrep/pull/208), I ran into an issue with Windows (and only Windows) failing to pip-install the package:

```
Run pip install --no-deps . --no-build-isolation
  pip install --no-deps . --no-build-isolation
  shell: C:\Program Files\Git\bin\bash.EXE -l {0}
  env:
    PYTHONPATH: /d/a/flowrep/flowrep/tests
    WRITE_ENVIRONMENT_OUTPUT_ENV_FILE: ./environment.yml
    INPUT_RUN_POST: true
    CONDA: C:\Users\runneradmin\miniconda3
failed to create process.
```

My hope is that this is a windows path issue which can be adequately resolved by uniformly calling `pip install..` instead via `python -m pip install...`. The current state is that we mix and match the two pip call routes.