### PR TITLE
fix(update_pyproject_dependencies): handle '- pip:' dict deps in lower-bound yaml

### DIFF
--- a/.support/update_pyproject_dependencies.py
+++ b/.support/update_pyproject_dependencies.py
@@ -115,6 +115,24 @@ def load_yaml(yaml_file: str) -> dict:
 
     yaml_bounds = {}
     for dependency in data["dependencies"]:
+        if isinstance(dependency, dict):
+            # A YAML `- pip:` block (PyPI-only deps installed by conda's
+            # pip backend) parses as a dict; descend into its list and
+            # capture the `==`-pinned entries. Anything without `==` is
+            # ignored — `load_yaml` only collects exact version bounds.
+            if "pip" in dependency:
+                for pip_dependency in dependency["pip"]:
+                    if "==" in pip_dependency:
+                        package, version = split_dependency(
+                            pip_dependency, "==", allow_no_version=True
+                        )
+                        yaml_bounds[package] = version
+            else:
+                raise ValueError(
+                    f"Unsupported dict-typed dependency entry in {yaml_file!r}: "
+                    f"{dependency!r}. Only `pip:` sub-lists are recognised."
+                )
+            continue
         package, version = split_dependency(dependency, "=", allow_no_version=True)
         yaml_bounds[package] = version
     return yaml_bounds


### PR DESCRIPTION
## Problem

\`load_yaml\` in \`.support/update_pyproject_dependencies.py\` iterates the yaml's \`dependencies\` list and calls \`split_dependency\` on every entry. \`split_dependency\` does \`dependency.replace(" ", "").split("=")\` — which crashes when an entry is a dict instead of a string:

\`\`\`
File "...update_pyproject_dependencies.py", line 126, in split_dependency
    split = dependency.replace(" ", "").split(delimiter)
AttributeError: 'dict' object has no attribute 'replace'
\`\`\`

This happens for any consumer with a \`- pip:\` block in its conda env yaml (PyPI-only deps installed via conda's pip backend) — for example:

\`\`\`yaml
channels:
  - conda-forge
dependencies:
  - python =3.10
  - numpy =1.22.0
  ...
  - pip
  - pip:
      - lz-GB-code==0.1.0
\`\`\`

The current code parses the conda entries fine but explodes on the \`- pip:\` dict entry, blocking the release workflow.

Affected repos I know about:
- \`pyiron/pyiron_workflow_lammps\` — already carries a local fork of this file in \`main\` (with the same fix, slightly less polished).
- \`pyiron/pyiron_workflow_atomistics\` — hit it on the v0.0.5 release attempt I just made; I've forked the script locally there too while waiting for this upstream fix.

## Fix

Detect dict-typed entries; if the key is \`pip\`, descend into the value list and parse \`==\`-pinned entries via the same \`split_dependency\` helper. Any other dict key raises a clear \`ValueError\` naming the yaml file and the offending entry.

Diff (single function, no other touches):

\`\`\`diff
     yaml_bounds = {}
     for dependency in data["dependencies"]:
-        package, version = split_dependency(dependency, "=", allow_no_version=True)
-        yaml_bounds[package] = version
+        if isinstance(dependency, dict):
+            # A YAML \`- pip:\` block (PyPI-only deps installed by conda's
+            # pip backend) parses as a dict; descend into its list and
+            # capture the \`==\`-pinned entries. Anything without \`==\` is
+            # ignored — \`load_yaml\` only collects exact version bounds.
+            if "pip" in dependency:
+                for pip_dependency in dependency["pip"]:
+                    if "==" in pip_dependency:
+                        package, version = split_dependency(
+                            pip_dependency, "==", allow_no_version=True
+                        )
+                        yaml_bounds[package] = version
+            else:
+                raise ValueError(
+                    f"Unsupported dict-typed dependency entry in {yaml_file!r}: "
+                    f"{dependency!r}. Only \`pip:\` sub-lists are recognised."
+                )
+            continue
+        package, version = split_dependency(dependency, "=", allow_no_version=True)
+        yaml_bounds[package] = version
     return yaml_bounds
\`\`\`

Behavioural notes:
- For \`pip:\` entries, the parser uses \`==\` as the split delimiter (PyPI pinning syntax) vs \`=\` for conda entries.
- Non-\`==\` PyPI entries (e.g. \`>=\`, unconstrained) are silently skipped — consistent with the existing \`allow_no_version=True\` semantics for conda entries that have no \`=\`.
- Non-\`pip\` dict entries raise, surfacing unexpected yaml shapes loudly.

## Notes vs. the lammps repo fork

The fork in \`pyiron/pyiron_workflow_lammps@main:.github/actions/.support/update_pyproject_dependencies.py\` carries the same logical fix but uses \`type(dependency) == dict\` and \`"pip" in dependency.keys()\`. I changed those to \`isinstance(...)\` / \`"pip" in dependency\` (ruff E721 / SIM118), and dropped two stray \`print()\` calls that look like leftover debug output. No semantic difference.

## Test plan

Local smoke test against \`pyiron_workflow_atomistics/.ci_support/lower_bound.yml\`:

\`\`\`
$ python -c "
import sys; sys.path.insert(0, '.support')
import update_pyproject_dependencies as m
bounds = m.load_yaml('.../lower_bound.yml')
print(bounds.get('lz-GB-code'))   # 0.1.0 — captured from the pip: block
print(bounds.get('numpy'))         # 1.22.0 — captured from the conda block
"
\`\`\`

→ OK; 16 bounds parsed; \`lz-GB-code\` correctly picked up from the \`- pip:\` block.

Negative-case smoke (synthetic yaml with a non-\`pip\` dict entry):

\`\`\`
$ python -c "import update_pyproject_dependencies as m; m.load_yaml('/tmp/bad.yml')"
ValueError: Unsupported dict-typed dependency entry in '/tmp/bad.yml': {'foobar': ['x']}. Only \`pip:\` sub-lists are recognised.
\`\`\`

→ OK; raises clearly.

## After this lands

I'll undo the local fork in \`pyiron_workflow_atomistics\` (PR pyiron/pyiron_workflow_atomistics#35) by reverting back to \`uses: pyiron/actions/.github/workflows/pyproject-release.yml@<new-tag>\`. Same option opens up for lammps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)