### PR TITLE
Gate `commit-updated-env` in `push-pull`

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
-      - uses: pyiron/actions/update-env-files@actions-4.2.0
+      - uses: pyiron/actions/update-env-files@actions-4.2.1
       - name: UpdateDependabotPR commit
         run: |
           git config --local user.email "pyiron@mpie.de"

--- a/.github/workflows/hatch-release.yml
+++ b/.github/workflows/hatch-release.yml
@@ -106,11 +106,11 @@ jobs:
     - name: Install npm dependencies
       if: inputs.use-node
       run: npm install
-    - uses: pyiron/actions/cached-miniforge@actions-4.2.0
+    - uses: pyiron/actions/cached-miniforge@actions-4.2.1
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.2.0
+    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.2.1
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -48,10 +48,10 @@ jobs:
 
   tests-and-coverage:
     if: contains(github.event.pull_request.labels.*.name, 'run_coverage')
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.2.0
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.2.1
     secrets: inherit
 
   code-ql:
     if: contains(github.event.pull_request.labels.*.name, 'run_CodeQL')
-    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.2.0
+    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.2.1
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -222,11 +222,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-docs-env@actions-4.2.0
+      - uses: pyiron/actions/write-docs-env@actions-4.2.1
         with:
           env-files: ${{ inputs.docs-env-files }}
         if: ${{ inputs.do-commit-updated-env }}
-      - uses: pyiron/actions/write-environment@actions-4.2.0
+      - uses: pyiron/actions/write-environment@actions-4.2.1
         with:
           env-files: ${{ inputs.notebooks-env-files }}
           output-env-file: .binder/environment.yml
@@ -253,11 +253,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@actions-4.2.0
+      - uses: pyiron/actions/add-to-python-path@actions-4.2.1
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/build-docs@actions-4.2.0
+      - uses: pyiron/actions/build-docs@actions-4.2.1
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.docs-env-files }}
@@ -268,17 +268,17 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@actions-4.2.0
+      - uses: pyiron/actions/add-to-python-path@actions-4.2.1
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/export-secret-env@actions-4.2.0
+      - uses: pyiron/actions/export-secret-env@actions-4.2.1
         if: ${{ inputs.notebooks-secret-env-map != '' }}
         env:
           PYIRON_ALL_SECRETS_JSON: ${{ toJSON(secrets) }}
         with:
           secret-env-map: ${{ inputs.notebooks-secret-env-map }}
-      - uses: pyiron/actions/build-notebooks@actions-4.2.0
+      - uses: pyiron/actions/build-notebooks@actions-4.2.1
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.notebooks-env-files }}
@@ -316,11 +316,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.2.0
+    - uses: pyiron/actions/add-to-python-path@actions-4.2.1
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.2.0
+    - uses: pyiron/actions/unit-tests@actions-4.2.1
       with:
         python-version: ${{ matrix.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -333,7 +333,7 @@ jobs:
   coverage:
     needs: commit-updated-env
     if: ${{ inputs.do-codecov || inputs.do-coveralls || inputs.do-codacy }}
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.2.0
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.2.1
     secrets: inherit
     with:
       tests-env-files: ${{ inputs.tests-env-files }}
@@ -353,11 +353,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.2.0
+    - uses: pyiron/actions/add-to-python-path@actions-4.2.1
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.2.0
+    - uses: pyiron/actions/unit-tests@actions-4.2.1
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.tests-env-files }}
@@ -372,11 +372,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/add-to-python-path@actions-4.2.0
+    - uses: pyiron/actions/add-to-python-path@actions-4.2.1
       if: inputs.extra-python-paths != ''
       with:
         path-dirs: ${{ inputs.extra-python-paths }}
-    - uses: pyiron/actions/unit-tests@actions-4.2.0
+    - uses: pyiron/actions/unit-tests@actions-4.2.1
       with:
         python-version: ${{ inputs.alternate-tests-python-version }}
         env-files: ${{ inputs.alternate-tests-env-files }}
@@ -392,7 +392,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/pip-check@actions-4.2.0
+      - uses: pyiron/actions/pip-check@actions-4.2.1
         with:
           python-version: ${{ inputs.python-version }}
 
@@ -447,7 +447,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
           architecture: x64
       - if: ${{ inputs.mypy-env-files != '' }}
-        uses: pyiron/actions/cached-miniforge@actions-4.2.0
+        uses: pyiron/actions/cached-miniforge@actions-4.2.1
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.mypy-env-files }}

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -1,4 +1,6 @@
 # This runs jobs which pyiron modules should run on pushes or PRs to main
+# (Propagating env changes only happens on local PRs, so otherwise make sure the env is
+# manually synced across files)
 # Usage:
 #   on:
 #     push:
@@ -215,22 +217,23 @@ on:
 jobs:
   commit-updated-env:  # Keep envs read by external sources (binder and readthedocs) up-to-date
     runs-on: ${{ inputs.runner }}
+    if: >-
+      inputs.do-commit-updated-env
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
-        if: ${{ inputs.do-commit-updated-env }}
       - uses: pyiron/actions/write-docs-env@actions-4.2.1
         with:
           env-files: ${{ inputs.docs-env-files }}
-        if: ${{ inputs.do-commit-updated-env }}
       - uses: pyiron/actions/write-environment@actions-4.2.1
         with:
           env-files: ${{ inputs.notebooks-env-files }}
           output-env-file: .binder/environment.yml
-        if: ${{ inputs.do-commit-updated-env }}
       - name: commit
         id: commit-docs-env
         continue-on-error: true  # Allow "failure" when there are no changes (the working tree is clean)
@@ -239,7 +242,6 @@ jobs:
           git config --local user.name "pyiron-runner"
           git add docs/environment.yml .binder/environment.yml
           git commit -m "[dependabot skip] Update env file" -a
-        if: ${{ inputs.do-commit-updated-env }}
       - name: push
         if: steps.commit-docs-env.outcome == 'success'  # But only push if we made it here without continue-on-error
         uses: ad-m/github-push-action@master
@@ -249,7 +251,7 @@ jobs:
 
   build-docs:
     needs: commit-updated-env
-    if: ${{ inputs.do-build-docs }}
+    if: ${{ inputs.do-build-docs && !cancelled() && needs.commit-updated-env.result != 'failure' }}
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -264,7 +266,7 @@ jobs:
 
   build-notebooks:
     needs: commit-updated-env
-    if: ${{ inputs.do-build-notebooks }}
+    if: ${{ inputs.do-build-notebooks && !cancelled() && needs.commit-updated-env.result != 'failure' }}
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -288,7 +290,7 @@ jobs:
 
   unit-tests:
     needs: commit-updated-env
-    if: ${{ inputs.do-unit-tests }}
+    if: ${{ inputs.do-unit-tests && !cancelled() && needs.commit-updated-env.result != 'failure' }}
     runs-on: ${{ matrix.operating-system }}
     # All three runners for the highest python version
     # Only the main for up to two more versions of python
@@ -332,7 +334,7 @@ jobs:
 
   coverage:
     needs: commit-updated-env
-    if: ${{ inputs.do-codecov || inputs.do-coveralls || inputs.do-codacy }}
+    if: ${{ (inputs.do-codecov || inputs.do-coveralls || inputs.do-codacy) && !cancelled() && needs.commit-updated-env.result != 'failure' }}
     uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.2.1
     secrets: inherit
     with:
@@ -349,7 +351,7 @@ jobs:
 
   benchmark-tests:
     needs: commit-updated-env
-    if: ${{ inputs.do-benchmark-tests }}
+    if: ${{ inputs.do-benchmark-tests && !cancelled() && needs.commit-updated-env.result != 'failure' }}
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
@@ -388,7 +390,7 @@ jobs:
 
   pip-check:
     needs: commit-updated-env
-    if: ${{ inputs.do-pip-check }}
+    if: ${{ inputs.do-pip-check && !cancelled() && needs.commit-updated-env.result != 'failure' }}
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -398,7 +400,7 @@ jobs:
 
   black:
     needs: commit-updated-env
-    if: ${{ inputs.do-black }}
+    if: ${{ inputs.do-black && !cancelled() && needs.commit-updated-env.result != 'failure' }}
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -411,7 +413,7 @@ jobs:
 
   ruff-check:
     needs: commit-updated-env
-    if: ${{ inputs.do-ruff-check }}
+    if: ${{ inputs.do-ruff-check && !cancelled() && needs.commit-updated-env.result != 'failure' }}
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -424,7 +426,7 @@ jobs:
 
   ruff-sort-imports:
     needs: commit-updated-env
-    if: ${{ inputs.do-ruff-sort-imports }}
+    if: ${{ inputs.do-ruff-sort-imports && !cancelled() && needs.commit-updated-env.result != 'failure' }}
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -437,7 +439,7 @@ jobs:
 
   mypy:
     needs: commit-updated-env
-    if: ${{ inputs.do-mypy }}
+    if: ${{ inputs.do-mypy && !cancelled() && needs.commit-updated-env.result != 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -83,11 +83,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - uses: actions/checkout@v4
-    - uses: pyiron/actions/cached-miniforge@actions-4.2.0
+    - uses: pyiron/actions/cached-miniforge@actions-4.2.1
       with:
         python-version: ${{ inputs.python-version }}
         env-files: ${{ inputs.env-files }}
-    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.2.0
+    - uses: pyiron/actions/update-pyproject-dependencies@actions-4.2.1
       with:
         input-toml: ${{ inputs.input-toml }}
         lower-bound-yaml: ${{ inputs.lower-bound-yaml }}

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -69,11 +69,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/add-to-python-path@actions-4.2.0
+      - uses: pyiron/actions/add-to-python-path@actions-4.2.1
         if: inputs.extra-python-paths != ''
         with:
           path-dirs: ${{ inputs.extra-python-paths }}
-      - uses: pyiron/actions/unit-tests@actions-4.2.0
+      - uses: pyiron/actions/unit-tests@actions-4.2.1
         with:
           python-version: ${{ inputs.python-version }}
           env-files: ${{ inputs.tests-env-files }}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The action needs the available secrets as JSON via `PYIRON_ALL_SECRETS_JSON`.
 A minimal use looks like:
 
 ```yaml
-- uses: pyiron/actions/export-secret-env@actions-4.2.0
+- uses: pyiron/actions/export-secret-env@actions-4.2.1
   env:
     PYIRON_ALL_SECRETS_JSON: ${{ toJSON(secrets) }}
   with:
@@ -141,7 +141,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.2.0
+    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.2.1
     secrets: inherit
 ```
 

--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -21,11 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.2.0
+  - uses: pyiron/actions/cached-miniforge@actions-4.2.1
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-docs-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.2.0
+  - uses: pyiron/actions/pyiron-config@actions-4.2.1
   - name: Build sphinx documentation
     shell: bash -l {0}
     run: |

--- a/build-notebooks/action.yml
+++ b/build-notebooks/action.yml
@@ -32,11 +32,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.2.0
+  - uses: pyiron/actions/cached-miniforge@actions-4.2.1
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.standard-notebooks-env-file }} ${{ inputs.env-files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.2.0
+  - uses: pyiron/actions/pyiron-config@actions-4.2.1
   - name: Build notebooks
     shell: bash -l {0}
     run: $GITHUB_ACTION_PATH/../.support/build_notebooks.sh "${{ inputs.notebooks-dir }}" "${{ inputs.exclusion-file }}" "${{ inputs.kernel }}" "${{ inputs.notebooks-working-directory }}"

--- a/cached-miniforge/action.yml
+++ b/cached-miniforge/action.yml
@@ -62,7 +62,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: pyiron/actions/write-environment@actions-4.2.0
+  - uses: pyiron/actions/write-environment@actions-4.2.1
     with:
       env-files: ${{ inputs.env-files }}
   - name: Calculate cache label info

--- a/pip-check/action.yml
+++ b/pip-check/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - uses: pyiron/actions/cached-miniforge@actions-4.2.0
+  - uses: pyiron/actions/cached-miniforge@actions-4.2.1
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ inputs.env-files }}

--- a/unit-tests/action.yml
+++ b/unit-tests/action.yml
@@ -72,11 +72,11 @@ runs:
       echo "ENV_FILES = ${ENV_FILES}"
       echo "env_files=$ENV_FILES" >> $GITHUB_OUTPUT
 
-  - uses: pyiron/actions/cached-miniforge@actions-4.2.0
+  - uses: pyiron/actions/cached-miniforge@actions-4.2.1
     with:
       python-version: ${{ inputs.python-version }}
       env-files: ${{ steps.prepare-env-files.outputs.env_files }}
-  - uses: pyiron/actions/pyiron-config@actions-4.2.0
+  - uses: pyiron/actions/pyiron-config@actions-4.2.1
   - name: Test
     shell: bash -l {0}
     run: |


### PR DESCRIPTION
So that it only works on PRs from inside the repo. My goal is to get PRs from forks to run here. This has the side effect of stopping PRs from dependabot from propagating their updates to secondary env files, but frankly that was spotty to start with, cf. the closed issue linked.

Closes #77 